### PR TITLE
Configs are now read from latest github. not from local filesystem

### DIFF
--- a/loti_wiki_gen/utils.py
+++ b/loti_wiki_gen/utils.py
@@ -38,3 +38,14 @@ def english_title(str):
     if subbed:
         return subbed[0].upper() + subbed[1:]
     return ""
+
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'


### PR DESCRIPTION
I don't see a case when wiki is generated for any version but latest. Anyway we have only one wiki version online.
Hence it makes sense to read `.cfg` files directly from latest campaign repository instead of local filesystem - and this is what this PR does.
However if you consider non-latest-docs usecase to be valid, I will add switch to make this behavior optional.
As a side effect generation is now way longer (~1 min) due to querying 1000+ unit files via HTTPS. I think this is not quite a problem, we don't generate docs too often

I checked generated wikis and they are exactly same as they were, except timestamp and version

Finally, I added some fancy ANSI coloring to output