### PR TITLE
update to work with the latest stable loti (3.2.6d)

### DIFF
--- a/abilities.wiki
+++ b/abilities.wiki
@@ -1,5 +1,5 @@
-This is an auto-generated wiki page listing all the abilities and weapon specials currently avalible in the campaign "Legend of the Invincibles". 
-This was generated at Wed Oct 31 20:12:22 2018 using version git-dea189d of LotI and version 0.3.5 of the generation script.
+This is an auto-generated wiki page listing all the abilities and weapon specials currently available in the campaign "Legend of the Invincibles". 
+This was generated at Tue Sep 21 22:36:25 2021 using version 3.2.6d of LotI and version 0.3.5.1 of the generation script.
 As this is auto-generated, DO NOT EDIT THIS PAGE.
 Instead, create a new issue at https://github.com/matsjoyce/LotIWikiGen/issues/new and the script will be adjusted.
 
@@ -7,498 +7,519 @@ Other LotI-related wiki pages:
 
 * https://wiki.wesnoth.org/LotI_Items &ndash; items, such as weapons and books
 * https://wiki.wesnoth.org/LotI_Standard_Advancements &ndash; general advancements such as legacies and books
-* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit specific advancements
+* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit-specific advancements
 * https://wiki.wesnoth.org/LotI_Abilities &ndash; abilities and weapon specials
 * https://wiki.wesnoth.org/LotI_Scenarios &ndash; scenario information
 * https://wiki.wesnoth.org/DeadlyUnitsFromLotI
 
 == Abilities ==
-=== absorbs (1) &ndash; dummy ===
+=== Other ===
+==== absorbs (1) &ndash; dummy ====
 <span style='color:#808080'><i>When this unit is hit, it takes its regular damage, but heals 1 HP after it.</i></span><br/>
 <br/>
-=== absorbs (2) &ndash; dummy ===
+==== absorbs (2) &ndash; dummy ====
 <span style='color:#808080'><i>When this unit is hit, it takes its regular damage, but heals 2 HP after it.</i></span><br/>
 <br/>
-=== absorbs (3) &ndash; dummy ===
+==== absorbs (3) &ndash; dummy ====
 <span style='color:#808080'><i>When this unit is hit, it takes its regular damage, but heals 3 HP after it.</i></span><br/>
 <br/>
-=== absorbs (4) &ndash; dummy ===
+==== absorbs (4) &ndash; dummy ====
 <span style='color:#808080'><i>When this unit is hit, it takes its regular damage, but heals 4 HP after it.</i></span><br/>
 <br/>
-=== adamant &ndash; resistance ===
-<span style='color:#808080'><i>This unit’s resistances are tripled, up to a maximum of 80%, when defending. Vulnerabilities are not affected.</i></span><br/>
-<br/>
-=== alliance &ndash; leadership ===
-<span style='color:#808080'><i>This unit is very well versed in team tactics so that adjacent units with the same ability deal 35% more damage.</i></span><br/>
-<br/>
-=== anathema &ndash; leadership ===
-<span style='color:#808080'><i>This unit's behaviour is loathsome, it spreads foul smell and droplets containing neisseria gonorrhoeae. Others absolutely loathe fighting next to it. Adjacent allies deal 30% less damage.</i></span><br/>
-<br/>
-=== antisocial &ndash; leadership ===
-<span style='color:#808080'><i>This unit's manners are incredibly bad, others hate fighting next to it. Adjacent allies deal 20% less damage.</i></span><br/>
-<br/>
-=== aura of hunger &ndash; dummy ===
+==== aura of hunger &ndash; dummy ====
 <span style='color:#808080'><i>All adjacent allies gain melee drain that drains 25% of the damage dealt (instead of the usual 50%).</i></span><br/>
 <br/>
-=== blood drinking &ndash; dummy ===
+==== blood drinking &ndash; dummy ====
 <span style='color:#808080'><i>When a unit adjacent to this unit takes damage, this unit heals 5% of the damage.</i></span><br/>
 <br/>
-=== bloodbound &ndash; regenerate ===
-<span style='color:#808080'><i>The unit will heal itself 32 HP per turn if adjacent to another unit with the bloodbound ability. If it is poisoned, it will remove the poison instead of healing.</i></span><br/>
+==== cancer &ndash; dummy ====
+<span style='color:#808080'><i>This unit is poisoned at the beginning of its turn. Because it's not an attack, the <i>immune to poison</i> ability does not apply.</i></span><br/>
 <br/>
-=== burns foes (POWER) &ndash; heals ===
-<span style='color:#808080'><i>The unit singes adjacent enemies at the beginning of your turn, causing a loss of POWER HP (max. down to 1 HP, never kills). The ability ignores any of the enemy's resistances or weaknesses, so it is very powerful against spirits!</i></span><br/>
-<br/>
-=== cancer &ndash; dummy ===
-<span style='color:#808080'><i>This unit is poisoned at the beginning of its turn.</i></span><br/>
-<br/>
-=== cantor &ndash; dummy ===
+==== cantor &ndash; dummy ====
 <span style='color:#808080'><i>This unit grants marksman to all ranged attacks of all adjacent allies.</i></span><br/>
 <br/>
-=== careful &ndash; resistance ===
-<span style='color:#808080'><i>This unit’s resistances are increased by INTENSITY, up to a maximum of 80%, when defending. Vulnerabilities are not affected.</i></span><br/>
+==== cowardice &ndash; dummy ====
+<span style='color:#808080'><i>If this unit runs out of moves with no adjacent units, it loses its attack that turn but gains its moves back.</i></span><br/>
 <br/>
-=== conviction (INTENSITY) &ndash; resistance ===
-<span style='color:#808080'><i>This unit's presence is so darkly ominous that all adjacent enemies struggle with the guilt of their evil deeds, reducing their fire, cold and arcane resistances by INTENSITY%.</i></span><br/>
-<br/>
-=== dark aura &ndash; dummy ===
+==== dark aura &ndash; dummy ====
 <span style='color:#808080'><i>All adjacent enemies will be poisoned at the beginning of their turn.</i></span><br/>
 <br/>
-=== darkens &ndash; illuminates ===
-<span style='color:#808080'><i>This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.</i></span>
-
-<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were dusk when it is day, and as if it were night when it is dusk.</i></span><br/>
+==== evisceration &ndash; dummy ====
+<span style='color:#808080'><i>When this unit kills another unit, nearby allies heal 10 HP, and are ridden of poison and slow.</i></span><br/>
 <br/>
-=== darkens badly &ndash; illuminates ===
-<span style='color:#808080'><i>This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.</i></span>
-
-<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were dusk when it is day, as if it were night when it is dusk and the improvement of the chaotic units during the night is incredible.</i></span><br/>
+==== feeding &ndash; dummy ====
+<span style='color:#808080'><i>This unit gains 1 hitpoint added to its maximum whenever it kills a living unit.</i></span><br/>
 <br/>
-=== darkens severely &ndash; illuminates ===
-<span style='color:#808080'><i>This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.</i></span>
-
-<span style='color:#808080'><i>Any units adjacent to this unit will fight almost as if it were night when it is day, as if it were darker than the darkest night when it is dusk and the improvement of the chaotic units during the night is incredible.</i></span><br/>
+==== firecast &ndash; dummy ====
+<span style='color:#808080'><i>When this unit hits with a melee attack in offence, a randomly chosen fire spell is cast at the target.</i></span><br/>
 <br/>
-=== Deathaura &ndash; heals ===
+==== flaming radiance &ndash; dummy ====
+<span style='color:#808080'><i>All adjacent foes to this unit take fire damage every turn. At first turn, they take 8 damage and this number increases by 8 every turn they stand in the range of this ability. This ability cannot kill.</i></span><br/>
+<br/>
+==== freezing aura &ndash; dummy ====
+<span style='color:#808080'><i>All adjacent enemies will be slowed at the beginning of their turn.</i></span><br/>
+<br/>
+==== from the ashes &ndash; dummy ====
+<span style='color:#808080'><i>If this unit is attacked and its hitpoints drop below 20, it heals 40 hitpoints and deals 40 fire damage to all nearby foes. This ability can be used only once per 10 turns.</i></span><br/>
+<br/>
+==== frostbite &ndash; dummy ====
+<span style='color:#808080'><i>This unit takes 24 cold damage at the beginning of its turn.</i></span><br/>
+<br/>
+==== greater evisceration &ndash; dummy ====
+<span style='color:#808080'><i>When this unit kills another unit, nearby allies heal 16 HP, and are ridden of poison and slow.</i></span><br/>
+<br/>
+==== hate speech &ndash; dummy ====
+<span style='color:#808080'><i>When an adjacent unit offensively hits an enemy, its attack damage increases by 1. The added damage bonus halves each turn (rounded down).</i></span><br/>
+<br/>
+==== immune to drain &ndash; dummy ====
+<span style='color:#808080'><i>This unit is immune to drain.</i></span><br/>
+<br/>
+==== immune to poison &ndash; dummy ====
+<span style='color:#808080'><i>Poisonous attacks have no effect on this unit.</i></span><br/>
+<br/>
+==== innocence &ndash; dummy ====
+<span style='color:#808080'><i>Through magical means, this unit looks so innocent that attacking it causes the attacker to suffer emotional trauma that makes it deal 1 less damage for each hit. The damage decreased this way halves each turn.</i></span><br/>
+<br/>
+==== killhunger &ndash; dummy ====
+<span style='color:#808080'><i>When this unit kills another unit, it heals 4 HP, and is ridden of poison and slow.</i></span><br/>
+<br/>
+==== leeches &ndash; dummy ====
+<span style='color:#808080'><i>All adjacent enemy units to a unit with this ability lose 2 hitpoints at the beginning of this unit's turn. The damage dealt heals the unit. It cannot kill.</i></span><br/>
+<br/>
+==== lesser evisceration &ndash; dummy ====
+<span style='color:#808080'><i>When this unit kills another unit, nearby allies heal 4 HP, and are ridden of poison and slow.</i></span><br/>
+<br/>
+==== lesser redeem &ndash; dummy ====
+<span style='color:#808080'><i>When this unit attacks another unit, there is a chance that the target will be absorbed, inversely proportional to enemy level. When the redeem count reaches a certain level, the unit's properties will improve.</i></span><br/>
+<br/>
+==== martyrdom &ndash; dummy ====
+<span style='color:#808080'><i>Hatred arouses among its comrades when this unit gets hurt. For every hit this unit takes, the damage of all adjacent allies increases by 1. The damage increased this way halves each turn (rounded down).</i></span><br/>
+<br/>
+==== mockery &ndash; dummy ====
+<span style='color:#808080'><i>When an attack against this unit misses, he/she heals 2 HP.</i></span><br/>
+<br/>
+==== murderlust &ndash; dummy ====
+<span style='color:#808080'><i>When this unit kills another unit, he/she heals 8 HP.</i></span><br/>
+<br/>
+==== murderous presence &ndash; dummy ====
+<span style='color:#808080'><i>All nearby allies get melee backstab.</i></span><br/>
+<br/>
+==== necromancy &ndash; dummy ====
+<span style='color:#808080'><i>If this unit dies, it becomes a lich.</i></span><br/>
+<br/>
+==== northfrost aura &ndash; dummy ====
+<span style='color:#808080'><i>All enemies in the range of two hexes from this unit will be slowed at the beginning of their turn.</i></span><br/>
+<br/>
+==== parasite &ndash; dummy ====
+<span style='color:#808080'><i>All adjacent allies to a unit with this ability lose 4 hitpoints at the beginning of this unit's turn. The damage dealt heals the unit. It cannot kill.</i></span><br/>
+<br/>
+==== penetrates &ndash; dummy ====
+<span style='color:#808080'><i>This unit gains 1 movement after attacking, allowing it to slowly progress through ranks of enemies if it can survive their attacks.</i></span><br/>
+<br/>
+==== producer &ndash; dummy ====
+<span style='color:#808080'><i>This unit occasionally earns some gold for his side.</i></span><br/>
+<br/>
+==== push &ndash; dummy ====
+<span style='color:#808080'><i>When an ally standing next to this unit finishes attacking, it gains one movement point.</i></span><br/>
+<br/>
+==== radiating insanity &ndash; dummy ====
+<span style='color:#808080'><i>All nearby allies fight with a bloodlust equal to the dwarvish berserk.</i></span><br/>
+<br/>
+==== radiation &ndash; dummy ====
+<span style='color:#808080'><i>All nearby allies get poisonous attacks.</i></span><br/>
+<br/>
+==== reflect &ndash; dummy ====
+<span style='color:#808080'><i>When this unit is hit, an half of the damage it took is dealt also to the attacker. It cannot kill, unlike thorns.</i></span><br/>
+<br/>
+==== regrowing &ndash; dummy ====
+<span style='color:#808080'><i>When this unit begins combat, offensively or defensively, it heals an amount of hitpoints equal to two times their level.</i></span><br/>
+<br/>
+==== resistant to slow &ndash; dummy ====
+<span style='color:#808080'><i>This unit has so much life energy in it, that it will break through any slowing effect almost instantly.</i></span><br/>
+<br/>
+==== retribution &ndash; dummy ====
+<span style='color:#808080'><i>When this unit is hit, an amount of fire damage equal to a quarter of the damage dealt hurts the attacker.</i></span><br/>
+<br/>
+==== soul eater &ndash; dummy ====
+<span style='color:#808080'><i>When this unit kills a certain amount of beings, it obtains special advancements.</i></span><br/>
+<br/>
+==== steals &ndash; dummy ====
+<span style='color:#808080'><i>When this unit hits an enemy with a melee attack, it has a chance to earn some gold.</i></span><br/>
+<br/>
+==== tax collector &ndash; dummy ====
+<span style='color:#808080'><i>When this unit hits an enemy, it has a chance to tax its own side and part it from some gold.</i></span><br/>
+<br/>
+==== temptation &ndash; dummy ====
+<span style='color:#808080'><i>This unit makes its enemies of opposite gender infatuated at the beginning of their turn, making them unable to attack, but able to break this charm by fleeing.</i></span><br/>
+<br/>
+==== thorns &ndash; dummy ====
+<span style='color:#808080'><i>Any unit that attacks this unit in melee suffers two points of piercing damage. Unlike reflect, it can kill.</i></span><br/>
+<br/>
+==== triggerable &ndash; dummy ====
+<span style='color:#808080'><i>This unit's attack damage increases by 1 when hit. Does not work when hit by a retaliating unit. The added damage bonus halves each turn (rounded down).</i></span><br/>
+<br/>
+==== unforgiving &ndash; dummy ====
+<span style='color:#808080'><i>This unit's attack deals 50% additional fire damage when directly hitting a unit type that hit it in the last 5 turns. Does not work when hit by a retaliating unit.</i></span><br/>
+<br/>
+==== unholy hunger &ndash; dummy ====
+<span style='color:#808080'><i>This unit craves for the souls of living beings. When it kills a living unit, it will heal 10 HP and its maximum HP will increase by 3. When it is not fed continually, it starts to starve, and loses 1 point of maximum HP more for each turn it did not kill something at the beginning of each turn. The hunger has no effect if the unit is cared by a healer or standing in a village.</i></span><br/>
+<br/>
+==== vindictive &ndash; dummy ====
+<span style='color:#808080'><i>This unit's attack damage increases by 1 when an adjacent ally is hit. Does not work when hit by a retaliating unit. The added damage bonus halves each turn (rounded down).</i></span><br/>
+<br/>
+==== wardrums &ndash; dummy ====
+<span style='color:#808080'><i>All adjacent members of the same side get +2 to movement at the start of their turn.</i></span><br/>
+<br/>
+==== warlord's rule &ndash; dummy ====
+<span style='color:#808080'><i>All nearby allies deal and take 50% more damage.</i></span><br/>
+<br/>
+==== weak reflect &ndash; dummy ====
+<span style='color:#808080'><i>When this unit is hit, an quarter of the damage it took is dealt also to the attacker. It cannot kill, unlike thorns.</i></span><br/>
+<br/>
+==== wrath &ndash; dummy ====
+<span style='color:#808080'><i>When offensively hitting an enemy, this unit's attack damage increases by 1. The added damage bonus halves each turn (rounded down).</i></span><br/>
+<br/>
+==== zeal aura &ndash; dummy ====
+<span style='color:#808080'><i>All nearby allies get firststrike.</i></span><br/>
+<br/>
+=== heals ===
+==== Deathaura &ndash; heals ====
 <span style='color:#808080'><i>This ability causes its bearer unit to hurt adjacent enemy units at the beginning of your turn (INTENSITY damage).</i></span>
 
 <span style='color:#808080'><i>Does not affect poisoned enemies.</i></span><br/>
 <br/>
-=== despair (INTENSITY) &ndash; leadership ===
-<span style='color:#808080'><i>This unit's presence is so darkly ominous that all adjacent enemies struggle with despair, dealing INTENSITY% less damage.</i></span><br/>
+==== burns foes (POWER) &ndash; heals ====
+<span style='color:#808080'><i>The unit singes adjacent enemies at the beginning of your turn, causing a loss of POWER HP (max. down to 1 HP, never kills). The ability ignores any of the enemy's resistances or weaknesses, so it is very powerful against spirits!</i></span><br/>
 <br/>
-=== evisceration &ndash; dummy ===
-<span style='color:#808080'><i>When this unit kills another unit, nearby allies heal 10 HP, and are ridden of poison and slow.</i></span><br/>
-<br/>
-=== exile &ndash; resistance ===
-<span style='color:#808080'><i>This unit’s resistances are increased by 10% (up to a maximum of 70%) if it has no adjacent allies.</i></span><br/>
-<br/>
-=== feeding &ndash; dummy ===
-<span style='color:#808080'><i>This unit gains 1 hitpoint added to its maximum whenever it kills a living unit.</i></span><br/>
-<br/>
-=== firecast &ndash; dummy ===
-<span style='color:#808080'><i>When this unit hits with a melee attack in offence, a randomly chosen fire spell is cast at the target.</i></span><br/>
-<br/>
-=== flaming radiance &ndash; dummy ===
-<span style='color:#808080'><i>All adjacent foes to this unit take fire damage every turn. At first turn, they take 8 damage and this number increases by 8 every turn they stand in the range of this ability. This ability cannot kill.</i></span><br/>
-<br/>
-=== forsaken &ndash; resistance ===
-<span style='color:#808080'><i>This unit’s resistances are increased by 20% (up to a maximum of 70%) if it has no adjacent allies.</i></span><br/>
-<br/>
-=== frail tide (INTENSITY) &ndash; resistance ===
-<span style='color:#808080'><i>This unit's presence is so darkly ominous that all adjacent enemies struggle with a decrepifying feeling of age and weariness, reducing their resistances to pierce, blade and impact by INTENSITY%.</i></span><br/>
-<br/>
-=== freezing aura &ndash; dummy ===
-<span style='color:#808080'><i>All adjacent enemies will be slowed at the beginning of their turn.</i></span><br/>
-<br/>
-=== from the ashes &ndash; dummy ===
-<span style='color:#808080'><i>If this unit is attacked and its hitpoints drop bellow 20, it heals 40 hitpoints and deals 40 fire damage to all nearby foes. This ability can be used only once per 10 turns.</i></span><br/>
-<br/>
-=== frostbite &ndash; dummy ===
-<span style='color:#808080'><i>This unit takes 24 cold damage at the beginning of its turn.</i></span><br/>
-<br/>
-=== great illumination &ndash; illuminates ===
-<span style='color:#808080'><i>This unit illuminates the surrounding area, making lawful units fight better, and chaotic units fight worse.</i></span>
-
-<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were almost day when it is night, better than if it were day when it is dusk, and far better during the day (worse if they are chaotic or liminal).</i></span><br/>
-<br/>
-=== greater evisceration &ndash; dummy ===
-<span style='color:#808080'><i>When this unit kills another unit, nearby allies heal 16 HP, and are ridden of poison and slow.</i></span><br/>
-<br/>
-=== hate speech &ndash; dummy ===
-<span style='color:#808080'><i>When an adjacent unit offensively hits an enemy, its attack damage increases by 1. The added damage bonus halves each turn (rounded down).</i></span><br/>
-<br/>
-=== heals +VALUE &ndash; heals ===
+==== heals +VALUE &ndash; heals ====
 <span style='color:#808080'><i>This unit combines herbal remedies with magic to heal units more quickly than is normally possible on the battlefield.</i></span>
 
 <span style='color:#808080'><i>A unit cared for by this healer may heal up to VALUE HP per turn, or be cured of poisoning.</i></span><br/>
 <br/>
-=== immune to drain &ndash; dummy ===
-<span style='color:#808080'><i>This unit is immune to drain.</i></span><br/>
+==== unholybane (INTENSITY) &ndash; heals ====
+<span style='color:#808080'><i>The unit damages adjacent undead enemies at the beginning of your turn, causing a loss of INTENSITY HP (max. down to 1 HP, never kills). The ability ignores any of the enemy's resistances or weaknesses, so it is very powerful against spirits!</i></span><br/>
 <br/>
-=== immune to poison &ndash; dummy ===
-<span style='color:#808080'><i>Poisonous attacks have no effect on this unit.</i></span><br/>
-<br/>
-=== improved illumination &ndash; illuminates ===
-<span style='color:#808080'><i>This unit illuminates the surrounding area, making lawful units fight better, and chaotic units fight worse.</i></span>
-
-<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were dusk when it is night, as if it were day when it is dusk, and even better during the day (worse if they are chaotic or liminal).</i></span><br/>
-<br/>
-=== innocence &ndash; dummy ===
-<span style='color:#808080'><i>Through magical means, this unit looks so innocent that attacking it causes the attacker to suffer emotional trauma that makes it deal 1 less damage for each hit. The damage decreased this way halves each turn.</i></span><br/>
-<br/>
-=== killhunger &ndash; dummy ===
-<span style='color:#808080'><i>When this unit kills another unit, it heals 4 HP, and is ridden of poison and slow.</i></span><br/>
-<br/>
-=== leadership &ndash; leadership ===
-<span style='color:#808080'><i>This unit can lead your own units that are next to it, making them fight better.</i></span>
-
-<span style='color:#808080'><i>Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels.</i></span><br/>
-<br/>
-=== leeches &ndash; dummy ===
-<span style='color:#808080'><i>All adjacent enemy units to a unit with this ability lose 2 hitpoints at the beginning of this unit's turn. The damage dealt heals the unit. It cannot kill.</i></span><br/>
-<br/>
-=== lesser ambush &ndash; hides ===
+=== hides ===
+==== lesser ambush &ndash; hides ====
 <span style='color:#808080'><i>This unit can hide in forest, and remain undetected by its enemies. But only in deciduous forest.</i></span>
 
 <span style='color:#808080'><i>Enemy units cannot see this unit while it is in forest, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement.</i></span><br/>
 <br/>
-=== lesser antisocial &ndash; leadership ===
-<span style='color:#808080'><i>This unit's manners are very bad, others hate fighting next to it. Adjacent allies deal 10% less damage.</i></span><br/>
-<br/>
-=== lesser evisceration &ndash; dummy ===
-<span style='color:#808080'><i>When this unit kills another unit, nearby allies heal 4 HP, and are ridden of poison and slow.</i></span><br/>
-<br/>
-=== lesser nightstalk &ndash; hides ===
+==== lesser nightstalk &ndash; hides ====
 <span style='color:#808080'><i>The unit becomes invisible during night, but only in forests, hills, mountains and villages.</i></span>
 
 <span style='color:#808080'><i>Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement.</i></span><br/>
 <br/>
-=== lesser redeem &ndash; dummy ===
-<span style='color:#808080'><i>When this unit attacks another unit, there is a chance that the target will be absorbed, inversely proportional to enemy level. When the redeem count reaches a certain level, the unit's properties will improve.</i></span><br/>
-<br/>
-=== martyrdom &ndash; dummy ===
-<span style='color:#808080'><i>Hatred arouses among its comrades when this unit gets hurt. For every hit this unit takes, the damage of all adjacent allies increases by 1. The damage increased this way halves each turn (rounded down).</i></span><br/>
-<br/>
-=== mockery &ndash; dummy ===
-<span style='color:#808080'><i>When an attack against this unit misses, he/she heals 2 HP.</i></span><br/>
-<br/>
-=== murderlust &ndash; dummy ===
-<span style='color:#808080'><i>When this unit kills another unit, he/she heals 8 HP.</i></span><br/>
-<br/>
-=== murderous presence &ndash; dummy ===
-<span style='color:#808080'><i>All nearby allies get melee backstab.</i></span><br/>
-<br/>
-=== NAME (INTENSITY) &ndash; leadership ===
-<span style='color:#808080'><i>Adjacent allies will do INTENSITY% more damage.</i></span><br/>
-<br/>
-=== NAME (POWER) &ndash; resistance ===
-<span style='color:#808080'><i>This unit can rally the adjacent allies to ignore damage taken better, increasing their resistances by POWER%, up to a maximum of 80%.</i></span><br/>
-<br/>
-=== necromancy &ndash; dummy ===
-<span style='color:#808080'><i>If this unit dies, it becomes a lich.</i></span><br/>
-<br/>
-=== nocturnal ambush &ndash; hides ===
+==== nocturnal ambush &ndash; hides ====
 <span style='color:#808080'><i>The unit becomes invisible in forests, but only at night.</i></span>
 
 <span style='color:#808080'><i>Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement.</i></span><br/>
 <br/>
-=== northfrost aura &ndash; dummy ===
-<span style='color:#808080'><i>All enemies in the range of two hexes from this unit will be slowed at the beginning of their turn.</i></span><br/>
-<br/>
-=== parasite &ndash; dummy ===
-<span style='color:#808080'><i>All adjacent allies to a unit with this ability lose 4 hitpoints at the beginning of this unit's turn. The damage dealt heals the unit. It cannot kill.</i></span><br/>
-<br/>
-=== penetrates &ndash; dummy ===
-<span style='color:#808080'><i>This unit gains 1 movement after attacking, allowing it to slowly progress through ranks of enemies if it can survive their attacks.</i></span><br/>
-<br/>
-=== producer &ndash; dummy ===
-<span style='color:#808080'><i>This unit occasionally earns some gold for his side.</i></span><br/>
-<br/>
-=== push &ndash; dummy ===
-<span style='color:#808080'><i>When an ally standing next to this unit finishes attacking, it gains one movement point.</i></span><br/>
-<br/>
-=== radiating insanity &ndash; dummy ===
-<span style='color:#808080'><i>All nearby allies fight with a bloodlust equal to the dwarvish berserk.</i></span><br/>
-<br/>
-=== radiation &ndash; dummy ===
-<span style='color:#808080'><i>All nearby allies get poisonous attacks.</i></span><br/>
-<br/>
-=== reflect &ndash; dummy ===
-<span style='color:#808080'><i>When this unit is hit, an half of the damage it took is dealt also to the attacker. It cannot kill, unlike thorns.</i></span><br/>
-<br/>
-=== regenerates (VALUE) &ndash; regenerate ===
-<span style='color:#808080'><i>The unit will heal itself VALUE HP per turn. If it is poisoned, it will remove the poison instead of healing.</i></span><br/>
-<br/>
-=== regenerates slightly &ndash; regenerate ===
-<span style='color:#808080'><i>The unit will heal itself 4 HP per turn. If it is poisoned, these two effects will negate themselves.</i></span><br/>
-<br/>
-=== regrowing &ndash; dummy ===
-<span style='color:#808080'><i>When this unit begins combat, offensively or defensively, it heals an amount of hitpoints equal to two times their level.</i></span><br/>
-<br/>
-=== resistant to slow &ndash; dummy ===
-<span style='color:#808080'><i>This unit has so much life energy in it, that it will break through any slowing effect almost instantly.</i></span><br/>
-<br/>
-=== retribution &ndash; dummy ===
-<span style='color:#808080'><i>When this unit is hit, an amount of fire damage equal to a quarter of the damage dealt hurts the attacker.</i></span><br/>
-<br/>
-=== shield (INTENSITY) &ndash; resistance ===
-<span style='color:#808080'><i>This unit's presence is so glorious that all adjacent allies are honoured and inspired by them, increasing their resistances by INTENSITY%, up to a maximum of 60%.</i></span><br/>
-<br/>
-=== snow ambush &ndash; hides ===
+==== snow ambush &ndash; hides ====
 <span style='color:#808080'><i>This unit can hide on frozen terrains, and remain undetected by its enemies.</i></span>
 
 <span style='color:#808080'><i>Enemy units cannot see this unit while it is on frozen terrains, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement.</i></span><br/>
 <br/>
-=== soul eater &ndash; dummy ===
-<span style='color:#808080'><i>When this unit kills a certain amount of beings, it obtains special advancements.</i></span><br/>
-<br/>
-=== spell eater &ndash; resistance ===
-<span style='color:#808080'><i>This unit feeds on nearby magical energies, increasing nearby allied units' arcane resistance by 100% and grows stronger when a nearby allied unit is hit with arcane, fire or cold damage.</i></span><br/>
-<br/>
-=== steals &ndash; dummy ===
-<span style='color:#808080'><i>When this unit hits an enemy with a melee attack, it has a chance to earn some gold.</i></span><br/>
-<br/>
-=== tax collector &ndash; dummy ===
-<span style='color:#808080'><i>When this unit hits an enemy, it has a chance to tax its side and part it from some gold.</i></span><br/>
-<br/>
-=== temptation &ndash; dummy ===
-<span style='color:#808080'><i>This unit makes its enemies of opposite gender infatuated at the beginning of their turn, making them unable to attack, but able to break this charm by fleeing.</i></span><br/>
-<br/>
-=== thorns &ndash; dummy ===
-<span style='color:#808080'><i>Any unit that attacks this unit in melee suffers two points of piercing damage. Unlike reflect, it can kill.</i></span><br/>
-<br/>
-=== triggerable &ndash; dummy ===
-<span style='color:#808080'><i>This unit's attack damage increases by 1 when hit. Does not work when hit by a retaliating unit. The added damage bonus halves each turn (rounded down).</i></span><br/>
-<br/>
-=== twilightstalk &ndash; hides ===
+==== twilightstalk &ndash; hides ====
 <span style='color:#808080'><i>The unit becomes invisible during dawn or dusk, hiding in long shadows created by the sun near the horizont.</i></span>
 
 <span style='color:#808080'><i>Enemy units cannot see this unit during dawn or dusk, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement.</i></span><br/>
 <br/>
-=== unforgiving &ndash; dummy ===
-<span style='color:#808080'><i>This unit's attack deals 50% additional fire damage when directly hitting a unit type that hit it in the last 5 turns. Does not work when hit by a retaliating unit.</i></span><br/>
+=== illuminates ===
+==== darkens &ndash; illuminates ====
+<span style='color:#808080'><i>This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.</i></span>
+
+<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were dusk when it is day, and as if it were night when it is dusk.</i></span><br/>
 <br/>
-=== unholy hunger &ndash; dummy ===
-<span style='color:#808080'><i>This unit craves for the souls of living beings. When it kills a living unit, it will heal 10 HP and its maximum HP will increase by 3. When it is not fed continually, it starts to starve, and loses 1 point of maximum HP more for each turn it did not kill something at the beginning of each turn. The hunger has no effect if the unit is cared by a healer or standing in a village.</i></span><br/>
+==== darkens badly &ndash; illuminates ====
+<span style='color:#808080'><i>This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.</i></span>
+
+<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were dusk when it is day, as if it were night when it is dusk and the improvement of the chaotic units during the night is incredible.</i></span><br/>
 <br/>
-=== unholybane (INTENSITY) &ndash; heals ===
-<span style='color:#808080'><i>The unit damages adjacent undead enemies at the beginning of your turn, causing a loss of INTENSITY HP (max. down to 1 HP, never kills). The ability ignores any of the enemy's resistances or weaknesses, so it is very powerful against spirits!</i></span><br/>
+==== darkens severely &ndash; illuminates ====
+<span style='color:#808080'><i>This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse.</i></span>
+
+<span style='color:#808080'><i>Any units adjacent to this unit will fight almost as if it were night when it is day, as if it were darker than the darkest night when it is dusk and the improvement of the chaotic units during the night is incredible.</i></span><br/>
 <br/>
-=== unyielding &ndash; resistance ===
+==== great illumination &ndash; illuminates ====
+<span style='color:#808080'><i>This unit illuminates the surrounding area, making lawful units fight better, and chaotic units fight worse.</i></span>
+
+<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were almost day when it is night, better than if it were day when it is dusk, and far better during the day (worse if they are chaotic or liminal).</i></span><br/>
+<br/>
+==== improved illumination &ndash; illuminates ====
+<span style='color:#808080'><i>This unit illuminates the surrounding area, making lawful units fight better, and chaotic units fight worse.</i></span>
+
+<span style='color:#808080'><i>Any units adjacent to this unit will fight as if it were dusk when it is night, as if it were day when it is dusk, and even better during the day (worse if they are chaotic or liminal).</i></span><br/>
+<br/>
+=== leadership ===
+==== NAME (INTENSITY) &ndash; leadership ====
+<span style='color:#808080'><i>Adjacent allies will do INTENSITY% more damage.</i></span><br/>
+<br/>
+==== alliance &ndash; leadership ====
+<span style='color:#808080'><i>This unit is very well versed in team tactics so that adjacent units with the same ability deal 35% more damage.</i></span><br/>
+<br/>
+==== anathema &ndash; leadership ====
+<span style='color:#808080'><i>This unit's behaviour is loathsome, it spreads foul smell and droplets containing neisseria gonorrhoeae. Others absolutely loathe fighting next to it. Adjacent allies deal 30% less damage.</i></span><br/>
+<br/>
+==== antisocial &ndash; leadership ====
+<span style='color:#808080'><i>This unit's manners are incredibly bad, others hate fighting next to it. Adjacent allies deal 20% less damage.</i></span><br/>
+<br/>
+==== despair (INTENSITY) &ndash; leadership ====
+<span style='color:#808080'><i>This unit's presence is so darkly ominous that all adjacent enemies struggle with despair, dealing INTENSITY% less damage.</i></span><br/>
+<br/>
+==== leadership (as level LEVEL unit) &ndash; leadership ====
+<span style='color:#808080'><i>This unit can lead your own units that are next to it, making them fight better.</i></span>
+
+<span style='color:#808080'><i>Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels.</i></span><br/>
+<br/>
+==== lesser antisocial &ndash; leadership ====
+<span style='color:#808080'><i>This unit's manners are very bad, others hate fighting next to it. Adjacent allies deal 10% less damage.</i></span><br/>
+<br/>
+=== regenerate ===
+==== bloodbound &ndash; regenerate ====
+<span style='color:#808080'><i>The unit will heal itself 32 HP per turn if adjacent to another unit with the bloodbound ability. If it is poisoned, it will remove the poison instead of healing.</i></span><br/>
+<br/>
+==== regenerates (VALUE) &ndash; regenerate ====
+<span style='color:#808080'><i>The unit will heal itself VALUE HP per turn. If it is poisoned, it will remove the poison instead of healing.</i></span><br/>
+<br/>
+==== regenerates slightly &ndash; regenerate ====
+<span style='color:#808080'><i>The unit will heal itself 4 HP per turn. If it is poisoned, these two effects will negate themselves.</i></span><br/>
+<br/>
+=== resistance ===
+==== NAME (POWER) &ndash; resistance ====
+<span style='color:#808080'><i>This unit can rally the adjacent allies to ignore damage taken better, increasing their resistances by POWER%, up to a maximum of 80%.</i></span><br/>
+<br/>
+==== adamant &ndash; resistance ====
+<span style='color:#808080'><i>This unit’s resistances are tripled, up to a maximum of 80%, when defending. Vulnerabilities are not affected.</i></span><br/>
+<br/>
+==== antimagic (INTENSITY) &ndash; resistance ====
+<span style='color:#808080'><i>This unit's presence weakens surrounding magic, increasing resistances of oneself and any nearby units by INTENSITY%, up to a maximum of 80%.</i></span><br/>
+<br/>
+==== careful &ndash; resistance ====
+<span style='color:#808080'><i>This unit’s resistances are increased by INTENSITY, up to a maximum of 80%, when defending. Vulnerabilities are not affected.</i></span><br/>
+<br/>
+==== conviction (INTENSITY) &ndash; resistance ====
+<span style='color:#808080'><i>This unit's presence is so darkly ominous that all adjacent enemies struggle with the guilt of their evil deeds, reducing their fire, cold and arcane resistances by INTENSITY%.</i></span><br/>
+<br/>
+==== exile &ndash; resistance ====
+<span style='color:#808080'><i>This unit’s resistances are increased by 10% (up to a maximum of 70%) if it has no adjacent allies.</i></span><br/>
+<br/>
+==== forsaken &ndash; resistance ====
+<span style='color:#808080'><i>This unit’s resistances are increased by 20% (up to a maximum of 70%) if it has no adjacent allies.</i></span><br/>
+<br/>
+==== frail tide (INTENSITY) &ndash; resistance ====
+<span style='color:#808080'><i>This unit's presence is so darkly ominous that all adjacent enemies struggle with a decrepifying feeling of age and weariness, reducing their resistances to pierce, blade and impact by INTENSITY%.</i></span><br/>
+<br/>
+==== shield (INTENSITY) &ndash; resistance ====
+<span style='color:#808080'><i>This unit's presence is so glorious that all adjacent allies are honoured and inspired by them, increasing their resistances by INTENSITY%, up to a maximum of 60%.</i></span><br/>
+<br/>
+==== spell eater &ndash; resistance ====
+<span style='color:#808080'><i>This unit feeds on nearby magical energies, increasing nearby allied units' arcane resistance by 100% and grows stronger when a nearby allied unit is hit with arcane, fire or cold damage.</i></span><br/>
+<br/>
+==== unyielding &ndash; resistance ====
 <span style='color:#808080'><i>This unit’s resistances are doubled, up to a maximum of 70%, when defending. Vulnerabilities are not affected.</i></span><br/>
 <br/>
-=== vindictive &ndash; dummy ===
-<span style='color:#808080'><i>This unit's attack damage increases by 1 when an adjacent ally is hit. Does not work when hit by a retaliating unit. The added damage bonus halves each turn (rounded down).</i></span><br/>
-<br/>
-=== wardrums &ndash; dummy ===
-<span style='color:#808080'><i>All adjacent members of the same side get +2 to movement at the start of their turn.</i></span><br/>
-<br/>
-=== warlord's rule &ndash; dummy ===
-<span style='color:#808080'><i>All nearby allies deal and take 50% more damage.</i></span><br/>
-<br/>
-=== weak reflect &ndash; dummy ===
-<span style='color:#808080'><i>When this unit is hit, an quarter of the damage it took is dealt also to the attacker. It cannot kill, unlike thorns.</i></span><br/>
-<br/>
-=== wrath &ndash; dummy ===
-<span style='color:#808080'><i>When offensively hitting an enemy, this unit's attack damage increases by 1. The added damage bonus halves each turn (rounded down).</i></span><br/>
-<br/>
-=== zeal &ndash; resistance ===
+==== zeal &ndash; resistance ====
 <span style='color:#808080'><i>This unit's resistances are doubled, up to a maximum of 70%, when attacking. Vulnerabilities are not affected.</i></span><br/>
 <br/>
-=== zeal aura &ndash; dummy ===
-<span style='color:#808080'><i>All nearby allies get firststrike.</i></span><br/>
-<br/>
 == Weapon Specials ==
-=== anarchy &ndash; damage ===
-<span style='color:#808080'><i>This attack does 50% more damage to lawful units.</i></span><br/>
-<br/>
-=== anger &ndash; attacks ===
-<span style='color:#808080'><i>When used offensively, this attack doubles the attacks done by both attacker and defender.</i></span><br/>
-<br/>
-=== chaos &ndash; chance_to_hit ===
-<span style='color:#808080'><i>When used defensively, this attacks damages all surrounding foes for a half of the damage, and it always has a 70% chance to hit regardless of the defensive ability of the attacking unit. Whether in defence or on attack, it is so tiring that the unit's damage decreases by 2 afterwards and then halves with each turn.</i></span><br/>
-<br/>
-=== chaotic &ndash; damage ===
-<span style='color:#808080'><i>This attack is 25% better at night and 25% worse at day.</i></span><br/>
-<br/>
-=== chaotic and lawful &ndash; damage ===
-<span style='color:#808080'><i>This attack is 25% better at night. This attack is 25% better at day.</i></span><br/>
-<br/>
-=== charge &ndash; damage ===
-<span style='color:#808080'><i>When used offensively, this attack deals multiplied damage to the target. It also causes this unit to take multiplied damage from the target's counterattack.</i></span><br/>
-<br/>
-=== charging backstab &ndash; damage ===
-<span style='color:#808080'><i>When used offensively, this attack deals double damage to the target if the target is facing backwards to the attacker. It also causes this unit to take double damage from the target’s counterattack.</i></span><br/>
-<br/>
-=== cleave &ndash; damage ===
-<span style='color:#808080'><i>This attack will hit additional enemies in the two hexes that are adjacent to both the attacker and defender, in a crescent moon shape, for 50% of the original damage. It is so tiring that the unit's damage decreases by 2 after the attack, the damage penalty will half each turn.</i></span><br/>
-<br/>
-=== cone &ndash; dummy ===
+=== Other ===
+==== cone &ndash; dummy ====
 <span style='color:#808080'><i>With this attack enemies next to attacker and target suffer 1/2 the damage. The foe behind the defender takes 1/2 of the damage too, while their adjacent comrades take 1/4 of it. It is so tiring that the unit's damage decreases by 6 after the attack, the damage penalty will half each turn.</i></span><br/>
 <br/>
-=== dazzle &ndash; dummy ===
+==== dazzle &ndash; dummy ====
 <span style='color:#808080'><i>This weapon special limits the target's chance to hit to 50% for one turn.</i></span><br/>
 <br/>
-=== disintegrate &ndash; damage ===
-<span style='color:#808080'><i>Every blow with this weapon has a 2% chance to kill an enemy without any checks.</i></span><br/>
-<br/>
-=== distant attack &ndash; attacks ===
-<span style='color:#808080'><i>When this attack is used, the enemy will not counter.</i></span><br/>
-<br/>
-=== doom &ndash; dummy ===
+==== doom &ndash; dummy ====
 <span style='color:#808080'><i>If this attack hits, opponent's resistances will drop by 5% until he advances.</i></span><br/>
 <br/>
-=== explosive &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used, all enemies adjacent to the target take 75% of the damage, and even those behind them will take a few if the damage is sufficiently high. It is so tiring that the unit's damage decreases by 10 after the attack, the damage penalty will half each turn.</i></span><br/>
-<br/>
-=== explosive damage &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used offensively, all units adjacent to the target take 10 damage.</i></span><br/>
-<br/>
-=== explosive leech &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used, all enemies next to the target take 1/4 of the damage the target was dealt and the life is added to the caster's health. It is so tiring that the unit's damage decreases by 6 after the attack, the damage penalty will half each turn.</i></span><br/>
-<br/>
-=== explosive slow &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used, all enemies adjacent to a target are slowed.</i></span><br/>
-<br/>
-=== explosive unprotected &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used, all units adjacent to the target take 75% of the damage, including allies. It is so tiring that the unit's damage decreases by 8 after the attack, the damage penalty will half each turn.</i></span><br/>
-<br/>
-=== extra damage (+5; impact) &ndash; dummy ===
+==== extra damage (+5; impact) &ndash; dummy ====
 <span style='color:#808080'><i>After the damage with this weapon is dealt, the target takes 5 points of impact damage, that is unaffected by charge or slow.</i></span><br/>
 <br/>
-=== focused &ndash; chance_to_hit ===
-<span style='color:#808080'><i>This attack always has at least a 80% chance to hit.</i></span><br/>
-<br/>
-=== greater backstab &ndash; damage ===
-<span style='color:#808080'><i>When used offensively, this attack deals 2.5 times more damage if there is an enemy of the target on the opposite side of the target, and that unit is not incapacitated (turned to stone or otherwise paralyzed).</i></span><br/>
-<br/>
-=== greater infect &ndash; poison ===
-<span style='color:#808080'><i>The target of this weapon specials becomes poisoned in a special way: if it dies from this toxin or is killed while affected by it, it becomes a Soulless.</i></span><br/>
-<br/>
-=== guided &ndash; chance_to_hit ===
-<span style='color:#808080'><i>This attack always has an 90% chance to hit, regardless of the defensive ability of the defending unit.</i></span><br/>
-<br/>
-=== hit and run &ndash; dummy ===
+==== hit and run &ndash; dummy ====
 <span style='color:#808080'><i>When this attack is used, the unit regains half of its max MP.</i></span><br/>
 <br/>
-=== horrid &ndash; dummy ===
+==== horrid &ndash; dummy ====
 <span style='color:#808080'><i>When this attack is used offensively, the damage of retaliation attacks is decreased by 33%.</i></span><br/>
 <br/>
-=== hose &ndash; dummy ===
+==== hose &ndash; dummy ====
 <span style='color:#808080'><i>If this attack us used, many enemies behind and around the original target are hit. It is so tiring that the unit's damage decreases by 12 after the attack, the damage penalty will half each turn.</i></span><br/>
 <br/>
-=== iceform &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used, the user is transformed into a moving block of ice, taking 33% less cold, pierce and blade damage. It works both offensively and defensively.</i></span><br/>
-<br/>
-=== imprecise &ndash; chance_to_hit ===
-<span style='color:#808080'><i>This attack has a 10% lower chance to hit.</i></span><br/>
-<br/>
-=== incinerate &ndash; dummy ===
+==== incinerate &ndash; dummy ====
 <span style='color:#808080'><i>This attack incinerates its targets. Burning units lose 16 HP every turn until they are cured. Flames can kill a unit, the attacker that incinerated the unit gets the experience.</i></span><br/>
 <br/>
-=== infect &ndash; poison ===
-<span style='color:#808080'><i>The target of this weapon specials becomes poisoned in a special way: if it dies from this toxin or is killed while affected by it, it becomes a Walking Corpse.</i></span><br/>
-<br/>
-=== kamikaze sprint &ndash; damage ===
-<span style='color:#808080'><i>If this attack hits offensively, the attacker first takes the damage of all the opponent's attacks. Then, the enemy behind the target takes a half of this attack's damage, the enemy behind him takes a quarter of the initial damage etc, until there are no more enemies in the row, and the attacker will appear there. If the opponent's damage would kill, the weapon special does not work.</i></span><br/>
-<br/>
-=== knockback &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used offensively, at the end of the fight the enemy will be knocked back.</i></span><br/>
-<br/>
-=== lawful &ndash; damage ===
-<span style='color:#808080'><i>This attack is 25% better at day and 25% worse at night.</i></span><br/>
-<br/>
-=== leeches &ndash; damage ===
-<span style='color:#808080'><i>This is similar to the drains ability, but it drains only 1/10 of the damage inflicted but it can leech also the magic bound in the undeath of non-living foes.</i></span><br/>
-<br/>
-=== lesser berserk (COUNT) &ndash; berserk ===
-<span style='color:#808080'><i>Whether used offensively or defensively, this attack presses the engagement until one of the combatants is slain, or COUNT rounds of attacks have occurred.</i></span><br/>
-<br/>
-=== lesser lethargy &ndash; dummy ===
+==== lesser lethargy &ndash; dummy ====
 <span style='color:#808080'><i>When hitting an enemy, the opponent's attack damage decreases by 1. The reduction of damage bonus halves each turn (rounded down).</i></span><br/>
 <br/>
-=== lethargy &ndash; dummy ===
+==== lethargy &ndash; dummy ====
 <span style='color:#808080'><i>When hitting an enemy, the opponent's attack damage decreases by 2. The reduction of damage bonus halves each turn (rounded down).</i></span><br/>
 <br/>
-=== lord of the flies &ndash; damage ===
-<span style='color:#808080'><i>This attack does quadruple damage to flies.</i></span><br/>
-<br/>
-=== lurk &ndash; damage ===
-<span style='color:#808080'><i>When used offensively and the target is not adjacent to any of its allies, it deals double damage to the target.</i></span><br/>
-<br/>
-=== mayhem &ndash; dummy ===
+==== mayhem &ndash; dummy ====
 <span style='color:#808080'><i>If this attack hits, opponent's damage is lowered by 1, until he advances.</i></span><br/>
 <br/>
-=== mind raid &ndash; dummy ===
-<span style='color:#808080'><i>This weapon special steals 1 experience from the opponent, increasing the user's experience. It does not work if the target has no experience.</i></span><br/>
+==== mind raid &ndash; dummy ====
+<span style='color:#808080'><i>This weapon special steals 2 experience from the opponent, increasing the user's experience. It does not work if the target does not have enough experience.</i></span><br/>
 <br/>
-=== misanthropia &ndash; damage ===
-<span style='color:#808080'><i>This attack does double damage to humans.</i></span><br/>
-<br/>
-=== misdraconia &ndash; damage ===
-<span style='color:#808080'><i>This attack does double damage to drakes and dragons.</i></span><br/>
-<br/>
-=== misdryadia &ndash; damage ===
-<span style='color:#808080'><i>This attack does double damage to elves.</i></span><br/>
-<br/>
-=== misnania &ndash; damage ===
-<span style='color:#808080'><i>This attack does double damage to dwarves.</i></span><br/>
-<br/>
-=== misorcia &ndash; damage ===
-<span style='color:#808080'><i>This attack does double damage to orcs.</i></span><br/>
-<br/>
-=== nosferatu's gorge &ndash; damage ===
-<span style='color:#808080'><i>Every blow with this attack has a chance to add all the victims' remaining hitpoints to the attacker's hitpoints, killing the victim. The chance depends on victim's level. Works only in offence.</i></span><br/>
-<br/>
-=== parry &ndash; dummy ===
+==== parry &ndash; dummy ====
 <span style='color:#808080'><i>When the target misses, the attacker will hit him without any checks.</i></span><br/>
 <br/>
-=== pierce &ndash; dummy ===
+==== pierce &ndash; dummy ====
 <span style='color:#808080'><i>If this attack is used, the enemy behind the target is hurt as well, for 1/2 of the damage. The user loses 2 damage points after the attack, the damage penalty will half each turn.</i></span><br/>
 <br/>
-=== plague (LANGUAGE_TYPE) &ndash; plague ===
-<span style='color:#808080'><i>When a unit is killed by a Plague attack, that unit is replaced with a unit on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages.</i></span><br/>
-<br/>
-=== purify &ndash; dummy ===
+==== purify &ndash; dummy ====
 <span style='color:#808080'><i>When an undead unit is killed by this attack, it becomes living again.</i></span><br/>
 <br/>
-=== quickstrike &ndash; attacks ===
-<span style='color:#808080'><i>When this attack is used, the attacker loses no movement. However, this does not give back the movement lost due to entering a unit's ZoC.</i></span><br/>
-<br/>
-=== Raijer's saloon &ndash; damage ===
-<span style='color:#808080'><i>Every blow with this attack has a chance to add all the victims' hitpoints to the hitpoints of attacker and attacker's nearby allies (divided by the number of healed units), killing the victim. The chance depends on victim's level. Works only in offence.</i></span><br/>
-<br/>
-=== shockwave &ndash; slow ===
-<span style='color:#808080'><i>This attack is so strong that it slows the target, and creates a shock wave that knocks all enemies adjacent to the target 1 hex away from it, and causes them to take 8 impact damage. When used defensively, it only slows the attacker.</i></span><br/>
-<br/>
-=== soul annihilation &ndash; damage ===
-<span style='color:#808080'><i>Every blow with this attack has a 1% chance to kill an enemy, dealing arcane damage to nearby enemies, the damage is the amount of victim's remaining health divided by the number of nearby enemies with arcane damage.</i></span><br/>
-<br/>
-=== soul extraction &ndash; damage ===
-<span style='color:#808080'><i>Every blow with this attack has a 1% chance to kill an enemy, summoning a Ghost in the process.</i></span><br/>
-<br/>
-=== soul thrash &ndash; damage ===
-<span style='color:#808080'><i>Every blow with this attack has a 1% chance to kill an enemy, adding the victims' level to the attacker's wrath (increasing the damage temporarily, the increase is halved every turn). Works only offensively.</i></span><br/>
-<br/>
-=== spiritual attack &ndash; damage ===
-<span style='color:#808080'><i>When this attack is used, the damage of physical retaliation attacks is divided by 3.</i></span><br/>
-<br/>
-=== storm &ndash; dummy ===
+==== storm &ndash; dummy ====
 <span style='color:#808080'><i>The damage of this attack will affect also a lot of other enemy units around the caster, and will also deal some impact damage. It is so tiring that the unit's damage decreases by 12 after the attack, the damage penalty will half each turn.</i></span><br/>
 <br/>
-=== struggle &ndash; chance_to_hit ===
-<span style='color:#808080'><i>This attack causes the opponent to have a 10% lower chance to hit.</i></span><br/>
-<br/>
-=== trickery &ndash; dummy ===
+==== trickery &ndash; dummy ====
 <span style='color:#808080'><i>If this attack hits offensively, opponent's defence on all terrains is lowered by 5%, until he advances.</i></span><br/>
 <br/>
-=== uber backstab &ndash; damage ===
+=== attacks ===
+==== anger &ndash; attacks ====
+<span style='color:#808080'><i>When used offensively, this attack doubles the attacks done by both attacker and defender.</i></span><br/>
+<br/>
+==== distant attack &ndash; attacks ====
+<span style='color:#808080'><i>When this attack is used, the enemy will not counter.</i></span><br/>
+<br/>
+==== quickstrike &ndash; attacks ====
+<span style='color:#808080'><i>When this attack is used, the attacker loses no movement. However, this does not give back the movement lost due to entering a unit's ZoC.</i></span><br/>
+<br/>
+==== whirlwind &ndash; attacks ====
+<span style='color:#808080'><i>When this attack is used, all enemies adjacent the attacker take the damage and the enemy cannot retaliate. It is so tiring that the unit's damage decreases by 10 after the attack, the damage penalty will half each turn.</i></span><br/>
+<br/>
+=== berserk ===
+==== lesser berserk (COUNT) &ndash; berserk ====
+<span style='color:#808080'><i>Whether used offensively or defensively, this attack presses the engagement until one of the combatants is slain, or COUNT rounds of attacks have occurred.</i></span><br/>
+<br/>
+=== chance_to_hit ===
+==== chaos &ndash; chance_to_hit ====
+<span style='color:#808080'><i>When used defensively, this attacks damages all surrounding foes for a half of the damage, and it always has a 70% chance to hit regardless of the defensive ability of the attacking unit. Whether in defence or on attack, it is so tiring that the unit's damage decreases by 2 afterwards and then halves with each turn.</i></span><br/>
+<br/>
+==== focused &ndash; chance_to_hit ====
+<span style='color:#808080'><i>This attack always has at least a 80% chance to hit.</i></span><br/>
+<br/>
+==== guided &ndash; chance_to_hit ====
+<span style='color:#808080'><i>This attack always has an 90% chance to hit, regardless of the defensive ability of the defending unit.</i></span><br/>
+<br/>
+==== imprecise &ndash; chance_to_hit ====
+<span style='color:#808080'><i>This attack has a 10% lower chance to hit.</i></span><br/>
+<br/>
+==== struggle &ndash; chance_to_hit ====
+<span style='color:#808080'><i>This attack causes the opponent to have a 10% lower chance to hit.</i></span><br/>
+<br/>
+=== damage ===
+==== Raijer's saloon &ndash; damage ====
+<span style='color:#808080'><i>Every blow with this attack has a chance to add all the victims' hitpoints to the hitpoints of attacker and attacker's nearby allies (divided by the number of healed units), killing the victim. The chance depends on victim's level. Works only in offence.</i></span><br/>
+<br/>
+==== anarchy &ndash; damage ====
+<span style='color:#808080'><i>This attack does 50% more damage to lawful units.</i></span><br/>
+<br/>
+==== chaotic &ndash; damage ====
+<span style='color:#808080'><i>This attack is 25% better at night and 25% worse at day.</i></span><br/>
+<br/>
+==== chaotic and lawful &ndash; damage ====
+<span style='color:#808080'><i>This attack is 25% better at night. This attack is 25% better at day.</i></span><br/>
+<br/>
+==== charge &ndash; damage ====
+<span style='color:#808080'><i>When used offensively, this attack deals multiplied damage to the target. It also causes this unit to take multiplied damage from the target's counterattack.</i></span><br/>
+<br/>
+==== charging backstab &ndash; damage ====
+<span style='color:#808080'><i>When used offensively, this attack deals double damage if there is an enemy of the target on the opposite side of the target, and that unit is not incapacitated (turned to stone or otherwise paralyzed). It also causes this unit to take double damage from the target’s counterattack.</i></span><br/>
+<br/>
+==== cleave &ndash; damage ====
+<span style='color:#808080'><i>This attack will hit additional enemies in the two hexes that are adjacent to both the attacker and defender, in a crescent moon shape, for 50% of the original damage. It is so tiring that the unit's damage decreases by 2 after the attack, the damage penalty will half each turn.</i></span><br/>
+<br/>
+==== disintegrate &ndash; damage ====
+<span style='color:#808080'><i>Every blow with this weapon has a 2% chance to kill an enemy without any checks.</i></span><br/>
+<br/>
+==== explosive &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used, all enemies adjacent to the target take 75% of the damage, and even those behind them will take a few if the damage is sufficiently high. It is so tiring that the unit's damage decreases by 10 after the attack, the damage penalty will half each turn.</i></span><br/>
+<br/>
+==== explosive damage &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used offensively, all units adjacent to the target take 10 damage.</i></span><br/>
+<br/>
+==== explosive leech &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used, all enemies next to the target take 1/4 of the damage the target was dealt and the life is added to the caster's health. It is so tiring that the unit's damage decreases by 6 after the attack, the damage penalty will half each turn.</i></span><br/>
+<br/>
+==== explosive slow &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used, all enemies adjacent to a target are slowed.</i></span><br/>
+<br/>
+==== explosive unprotected &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used, all units adjacent to the target take 75% of the damage, including allies. It is so tiring that the unit's damage decreases by 8 after the attack, the damage penalty will half each turn.</i></span><br/>
+<br/>
+==== greater backstab &ndash; damage ====
+<span style='color:#808080'><i>When used offensively, this attack deals 2.5 times more damage if there is an enemy of the target on the opposite side of the target, and that unit is not incapacitated (turned to stone or otherwise paralyzed).</i></span><br/>
+<br/>
+==== iceform &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used, the user is transformed into a moving block of ice, taking 33% less cold, pierce and blade damage. It works both offensively and defensively.</i></span><br/>
+<br/>
+==== kamikaze sprint &ndash; damage ====
+<span style='color:#808080'><i>If this attack hits offensively, the attacker first takes the damage of all the opponent's attacks. Then, the enemy behind the target takes a half of this attack's damage, the enemy behind him takes a quarter of the initial damage etc, until there are no more enemies in the row, and the attacker will appear there. If the opponent's damage would kill, the weapon special does not work.</i></span><br/>
+<br/>
+==== knockback &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used offensively, at the end of the fight the enemy will be knocked back.</i></span><br/>
+<br/>
+==== lawful &ndash; damage ====
+<span style='color:#808080'><i>This attack is 25% better at day and 25% worse at night.</i></span><br/>
+<br/>
+==== leeches &ndash; damage ====
+<span style='color:#808080'><i>This is similar to the drains ability, but it drains only 1/10 of the damage inflicted but it can leech also the magic bound in the undeath of non-living foes.</i></span><br/>
+<br/>
+==== lord of the flies &ndash; damage ====
+<span style='color:#808080'><i>This attack does quadruple damage to flies.</i></span><br/>
+<br/>
+==== lurk &ndash; damage ====
+<span style='color:#808080'><i>When used offensively and the target is not adjacent to any of its allies, it deals double damage to the target.</i></span><br/>
+<br/>
+==== misanthropia &ndash; damage ====
+<span style='color:#808080'><i>This attack does double damage to humans.</i></span><br/>
+<br/>
+==== misdraconia &ndash; damage ====
+<span style='color:#808080'><i>This attack does double damage to drakes and dragons.</i></span><br/>
+<br/>
+==== misdryadia &ndash; damage ====
+<span style='color:#808080'><i>This attack does double damage to elves.</i></span><br/>
+<br/>
+==== misnania &ndash; damage ====
+<span style='color:#808080'><i>This attack does double damage to dwarves.</i></span><br/>
+<br/>
+==== misorcia &ndash; damage ====
+<span style='color:#808080'><i>This attack does double damage to orcs.</i></span><br/>
+<br/>
+==== nosferatu's gorge &ndash; damage ====
+<span style='color:#808080'><i>Every blow with this attack has a chance to add all the victims' remaining hitpoints to the attacker's hitpoints, killing the victim. The chance depends on victim's level. Works only in offence.</i></span><br/>
+<br/>
+==== soul annihilation &ndash; damage ====
+<span style='color:#808080'><i>Every blow with this attack has a 1% chance to kill an enemy, dealing arcane damage to nearby enemies, the damage is the amount of victim's remaining health divided by the number of nearby enemies with arcane damage.</i></span><br/>
+<br/>
+==== soul extraction &ndash; damage ====
+<span style='color:#808080'><i>Every blow with this attack has a 1% chance to kill an enemy, summoning a Ghost in the process.</i></span><br/>
+<br/>
+==== soul thrash &ndash; damage ====
+<span style='color:#808080'><i>Every blow with this attack has a 1% chance to kill an enemy, adding the victims' level to the attacker's wrath (increasing the damage temporarily, the increase is halved every turn). Works only offensively.</i></span><br/>
+<br/>
+==== spiritual attack &ndash; damage ====
+<span style='color:#808080'><i>When this attack is used, the damage of physical retaliation attacks is divided by 3.</i></span><br/>
+<br/>
+==== uber backstab &ndash; damage ====
 <span style='color:#808080'><i>When used offensively, this attack deals triple damage if there is an enemy of the target on the opposite side of the target, and that unit is not incapacitated (turned to stone or otherwise paralyzed).</i></span><br/>
 <br/>
-=== unholybane &ndash; damage ===
+==== unholybane &ndash; damage ====
 <span style='color:#808080'><i>This attack does triple damage to undead (also other non-monster creations of magic).</i></span><br/>
 <br/>
-=== whirlwind &ndash; attacks ===
-<span style='color:#808080'><i>When this attack is used, all enemies adjacent the attacker take the damage and the enemy cannot retaliate. It is so tiring that the unit's damage decreases by 10 after the attack, the damage penalty will half each turn.</i></span><br/>
+=== plague ===
+==== plague (LANGUAGE_TYPE) &ndash; plague ====
+<span style='color:#808080'><i>When a unit is killed by a Plague attack, that unit is replaced with a unit on the same side as the unit with the Plague attack. This doesn’t work on Undead or units in villages.</i></span><br/>
+<br/>
+=== poison ===
+==== greater infect &ndash; poison ====
+<span style='color:#808080'><i>The target of this weapon specials becomes poisoned in a special way: if it dies from this toxin or is killed while affected by it, it becomes a Soulless.</i></span><br/>
+<br/>
+==== infect &ndash; poison ====
+<span style='color:#808080'><i>The target of this weapon specials becomes poisoned in a special way: if it dies from this toxin or is killed while affected by it, it becomes a Walking Corpse.</i></span><br/>
+<br/>
+=== slow ===
+==== shockwave &ndash; slow ====
+<span style='color:#808080'><i>This attack is so strong that it slows the target, and creates a shock wave that knocks all enemies adjacent to the target 1 hex away from it, and causes them to take 8 impact damage. When used defensively, it only slows the attacker.</i></span><br/>
 <br/>

--- a/items.wiki
+++ b/items.wiki
@@ -1,5 +1,5 @@
-This is an auto-generated wiki page listing all the items currently avalible in the campaign "Legend of the Invincibles". 
-This was generated at Wed Oct 31 20:12:22 2018 using version git-dea189d of LotI and version 0.3.5 of the generation script.
+This is an auto-generated wiki page listing all the items currently available in the campaign "Legend of the Invincibles". 
+This was generated at Tue Sep 21 22:36:25 2021 using version 3.2.6d of LotI and version 0.3.5.1 of the generation script.
 As this is auto-generated, DO NOT EDIT THIS PAGE.
 Instead, create a new issue at https://github.com/matsjoyce/LotIWikiGen/issues/new and the script will be adjusted.
 
@@ -7,55 +7,12 @@ Other LotI-related wiki pages:
 
 * https://wiki.wesnoth.org/LotI_Items &ndash; items, such as weapons and books
 * https://wiki.wesnoth.org/LotI_Standard_Advancements &ndash; general advancements such as legacies and books
-* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit specific advancements
+* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit-specific advancements
 * https://wiki.wesnoth.org/LotI_Abilities &ndash; abilities and weapon specials
 * https://wiki.wesnoth.org/LotI_Scenarios &ndash; scenario information
 * https://wiki.wesnoth.org/DeadlyUnitsFromLotI
 
-=== 100 gold &ndash; gold ===
-<span style='color:#808080'><i>Why conquer when you can buy?</i></span><br/>
-<span style='color:#808080'><i>100 gold</i></span><br/>
-<br/>
-=== 200 gold &ndash; gold ===
-<span style='color:#808080'><i>Money will not buy you anything. It is you who has to buy it for money.</i></span><br/>
-<span style='color:#808080'><i>200 gold</i></span><br/>
-<br/>
-=== 50 gold &ndash; gold ===
-<span style='color:#808080'><i>Money is more powerful than magic.</i></span><br/>
-<span style='color:#808080'><i>50 gold</i></span><br/>
-<br/>
-=== Absence of Purpose and Meaning &ndash; staff ===
-<span style='color:#808080'><i>Do not look for the meaning of this. There is none.</i></span><br/>
-<span style='color:green'>Damage increased by 4</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Spells suck 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to pierce decreased by 20%</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: submerge</span><br/>
-<br/>
-=== Acantha's Cloak &ndash; cloak ===
-<span style='color:#808080'><i>She was forced to abandon politics and care about children. She indoctrinated them with evil.</i></span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<br/>
-=== Aevyn's Wrath &ndash; sword ===
-<span style='color:#808080'><i>I cannot quite figure out how to use this thing.</i></span><br/>
-<span style='color:green'>Damage decreased by 20% (in EASY difficulty), 30% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (10)]]</span><br/>
-<br/>
-=== Al-Fuṣūl wa al-ghāyāt &ndash; limited ===
-<span style='color:#808080'><i>They would not have accepted a spoken lie,
-but whips were raised to strike them,
-traditions were brought to them.</i></span><br/>
-<span style='color:purple'>10% to arcane resistance (requires [[#Theophrastus Redivivus_.E2.80.93_limited|Theophrastus Redivivus]])</span><br/>
-<span style='color:purple'>New ability: frail tide (10) (requires [[#Treatise of the Three Impostors_.E2.80.93_limited|Treatise of the Three Impostors]])</span><br/>
-<br/>
-=== Amethyst &ndash; gem ===
-<span style='color:#808080'><i>These purple precious stones always attracted people for their massive magical power. However, its use as decoration by those without any knowledge of magic is widespread.</i></span><br/>
-<br/>
+== amulet ==
 === Amulet of Lich's Bane &ndash; amulet ===
 <span style='color:#808080'><i>Learn what the enemy will use against you and prepare yourself for it.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
@@ -93,6 +50,111 @@ traditions were brought to them.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
 <span style='color:#60A0FF'>Sets alignment to liminal</span><br/>
 <br/>
+=== Ascent &ndash; amulet ===
+<span style='color:#808080'><i>Wizards do not need manual skills.</i></span><br/>
+<span style='color:green'>Damage decreased by 65% (in EASY difficulty), 75% (in MEDIUM difficulty), 85% (in HARD difficulty)</span><br/>
+<span style='color:green'>Increases all magical damages by 50% (in EASY difficulty), 45% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<br/>
+=== Black Widow &ndash; amulet ===
+<span style='color:#808080'><i>That horrid thing corrupts the very air around us!</i></span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
+<br/>
+=== Crapsack World &ndash; amulet ===
+<span style='color:#808080'><i>'Oh, almighty god, why did you create this world?'
+'It was not me. I have a perfect alibi, by the way.'</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 15%</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Demon Core &ndash; amulet ===
+<span style='color:#808080'><i>If you awaken it, foul light will ravage flesh.</i></span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#radiation_.E2.80.93_dummy|radiation]]</span><br/>
+<br/>
+=== Eidolon's Necklace &ndash; amulet ===
+<span style='color:#808080'><i>He was ingenious enough to become something new, not a pack of bones but a spirit. An opaque one.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
+<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
+<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
+<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
+<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
+<span style='color:purple'>1 to movement (requires [[#Eidolon's Boots_.E2.80.93_boots|Eidolon's Boots]])</span><br/>
+<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
+<span style='color:purple'>New ability: Frail Tide (15) (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
+<br/>
+=== Frozen Locket &ndash; amulet ===
+<span style='color:#808080'><i>Frozen memories shall thaw and redeem.</i></span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#freezing aura_.E2.80.93_dummy|freezing aura]]</span><br/>
+<br/>
+=== Havoc Bliss &ndash; amulet ===
+<span style='color:#808080'><i>Destruction can save you from suffering if you do it right.</i></span><br/>
+<span style='color:green'>Damage increased by 15%</span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Hydraulic Core &ndash; amulet ===
+<span style='color:#808080'><i>Purpose... unknown. Origin... unknown. Material... unknown. Mode of operation... unknown.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<br/>
+=== Leechward &ndash; amulet ===
+<span style='color:#808080'><i>Transform your blood to acid and nobody will drink it.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to drain_.E2.80.93_dummy|immune to drain]]</span><br/>
+<br/>
+=== Liquid Hatred &ndash; amulet ===
+<span style='color:#808080'><i>The essence of liquid hatred, purified and distilled.</i></span><br/>
+<span style='color:green'>Damage decreased by 3</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<br/>
+=== Lucky Farmer's Amulet &ndash; amulet ===
+<span style='color:#808080'><i>Look at this trinket I found in my haystack. It will protect me from the atrocities of war.</i></span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
+<br/>
+=== Tears of the Dead &ndash; amulet ===
+<span style='color:#808080'><i>Pity the walking dead for they know no pleasure.</i></span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to drain_.E2.80.93_dummy|immune to drain]]</span><br/>
+<br/>
+=== The gloomy Amulet &ndash; amulet ===
+<span style='color:#808080'><i>Bring sadness to your enemies by showing them how weak they are.</i></span><br/>
+<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#The gloomy Cloak_.E2.80.93_cloak|The gloomy Cloak]])</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#The gloomy Ring_.E2.80.93_ring|The gloomy Ring]])</span><br/>
+<br/>
+=== Unthought Memories &ndash; amulet ===
+<span style='color:#808080'><i>Your life's experience may disappear when you perish, but once somebody will come to the same experience.</i></span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 5%</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 5%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:purple'>4% to all physical resistances (requires [[#Unseen Writings_.E2.80.93_cloak|Unseen Writings]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Unspoken Words_.E2.80.93_gauntlets|Unspoken Words]])</span><br/>
+<span style='color:purple'>4% to magical resistances (requires [[#Unsung Odes_.E2.80.93_armour|Unsung Odes]])</span><br/>
+<br/>
+== armour ==
 === Ancient Armour &ndash; armour ===
 <span style='color:#808080'><i>Our ancestors were very strong if they could carry this around and run in it.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 22%</span><br/>
@@ -106,29 +168,17 @@ traditions were brought to them.</i></span><br/>
 <span style='color:green'>Increases all magical damages by 8%</span><br/>
 <span style='color:#60A0FF'>2 fewer movement points</span><br/>
 <br/>
-=== Angel of Death's Ring &ndash; ring ===
-<span style='color:#808080'><i>Death is the end, but sometimes an end is needed.</i></span><br/>
+=== Ancient Armour of the Power of the Ancients &ndash; armour ===
+<span style='color:#808080'><i>The Ancients knew that imbuing armours with ancient power will make even the most ancient armour useful.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 22%</span><br/>
+<span style='color:green'>Damage increased by 15%</span><br/>
 <span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 7%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 7%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 7%</span><br/>
-<span style='color:purple'>+12 to hitpoints (requires [[#Cloak of the Pale Rider_.E2.80.93_cloak|Cloak of the Pale Rider]])</span><br/>
-<span style='color:purple'>5% to all resistances (requires [[#Amulet of the Last Guide_.E2.80.93_amulet|Amulet of the Last Guide]])</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>2 fewer movement points</span><br/>
 <br/>
-=== Anger &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>If we were not born to rage, why would we have the ability to rage then?</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal, 3 Rubies and 1 Emerald</span><br/>
-<br/>
-=== Apricity &ndash; helm ===
-<span style='color:#808080'><i>In winter, the burning sun is actually enjoyable.</i></span><br/>
+=== Archer's Leather Armour &ndash; armour ===
+<span style='color:#808080'><i>Better do not let enemies anywhere near you when wearing this.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
 === Armour of the King &ndash; armour ===
 <span style='color:#808080'><i>King's armour protected the usurper, but it did not suffice to prevent wizards from revolting.</i></span><br/>
@@ -136,63 +186,11 @@ traditions were brought to them.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
 <span style='color:#60A0FF'>2 fewer movement points</span><br/>
+<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on mountains set to 1</span><br/>
 <span style='color:purple'>New Ability: warlord's rule (requires [[#Sceptre of the King_.E2.80.93_mace|Sceptre of the King]])</span><br/>
 <span style='color:purple'>1 more movement point (requires [[#Crown of the King_.E2.80.93_helm|Crown of the King]])</span><br/>
 <span style='color:purple'>4 more hitpoints per level (requires [[#Ring of the King_.E2.80.93_ring|Ring of the King]])</span><br/>
-<br/>
-=== Ashes of Dead Suns &ndash; staff ===
-<span style='color:#808080'><i>Things that destroy stars can destroy anything. According to one of a thousand hypotheses.</i></span><br/>
-<span style='color:#60A0FF'>15% chance to strike a devastating blow</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<br/>
-=== Avenging Fire &ndash; sword ===
-<span style='color:#808080'><i>Burn! Let the hair catch fire and help the skin burn. Ignite the skin and help the flesh burn.</i></span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#flaming radiance_.E2.80.93_dummy|flaming radiance]]</span><br/>
-<br/>
-=== Axe of Perun &ndash; axe ===
-<span style='color:#808080'><i>Perun's axe smote the wicked with thundering rage.</i></span><br/>
-<span style='color:green'>Damage increased by 55% (in EASY difficulty), 35% (in MEDIUM difficulty), 15% (in HARD difficulty)</span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<br/>
-=== Ballista &ndash; xbow ===
-<span style='color:#808080'><i>Are you sure that thing is hand-held?</i></span><br/>
-<span style='color:green'>Damage increased by 100% (in EASY difficulty), 80% (in MEDIUM difficulty), 60% (in HARD difficulty)</span><br/>
-<br/>
-=== Balls of Steel &ndash; sling ===
-<span style='color:#808080'><i>You will need courage in this cruel world.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
-<br/>
-=== Barbaric Glory &ndash; axe ===
-<span style='color:#808080'><i>Abandon the order, attack them randomly when unprepared.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 45% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
-<br/>
-=== Bean Shooter &ndash; thunderstick ===
-<span style='color:#808080'><i>Put there raw beans instead of a bullet, it will hit so many enemies.</i></span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#cone_.E2.80.93_dummy|cone]]</span><br/>
-<br/>
-=== Beelzebub's Hammer &ndash; mace ===
-<span style='color:#808080'><i>Where is Bruce gone?</i></span><br/>
-<span style='color:green'>Damage increased by 10% (in EASY difficulty), 25% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#lord of the flies_.E2.80.93_damage|lord of the flies]]</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
 <br/>
 === Beyond Death &ndash; armour ===
 <span style='color:#808080'><i>Death can be temporary.</i></span><br/>
@@ -204,91 +202,470 @@ traditions were brought to them.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 40%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane decreased by 25%</span><br/>
 <br/>
-=== Beyond the Grasp of Men &ndash; cloak ===
-<span style='color:#808080'><i>Fast, evasive and seeing further than most. No man shall catch the unreachable.</i></span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 15%</span><br/>
+=== Cunctator's Armour &ndash; armour ===
+<span style='color:#808080'><i>Enemies were bored to death when Cunctator finally attacked.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 22%</span><br/>
+<span style='color:#60A0FF'>2 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#shield (INTENSITY)_.E2.80.93_resistance|shield (40)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#antisocial_.E2.80.93_leadership|antisocial]]</span><br/>
+<span style='color:purple'>5% to all resistances (requires [[#Cunctator's sword_.E2.80.93_sword|Cunctator's Sword]])</span><br/>
+<span style='color:purple'>5% to all resistances (requires [[#Cunctator's Helmet_.E2.80.93_helm|Cunctator's Helmet]])</span><br/>
+<br/>
+=== Dark Sarcasm &ndash; armour ===
+<span style='color:#808080'><i>You missed! You cannot even hit me! Hahahaha! I feel so good to see you fail, loser!</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#mockery_.E2.80.93_dummy|mockery]]</span><br/>
+<br/>
+=== Defender of the Faith &ndash; armour ===
+<span style='color:#808080'><i>We shall clear the world of this filth!</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 15%</span><br/>
 <span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
-=== Black Pearl &ndash; gem ===
-<span style='color:#808080'><i>Black pearls are legendarily rare and powerful items, investigated because of its powers reaching beyond the borders of standard magic.</i></span><br/>
+=== Eidolon's Armour &ndash; armour ===
+<span style='color:#808080'><i>Clothes, masks and cosmetics helped him conceal his etherealness, his defeat of an undead army made him a nobleman.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
+<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
+<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
+<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
+<span style='color:purple'>1 to movement (requires [[#Eidolon's Boots_.E2.80.93_boots|Eidolon's Boots]])</span><br/>
+<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
+<span style='color:purple'>New ability: Wrath (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
 <br/>
-=== Black Raptor &ndash; xbow ===
-<span style='color:#808080'><i>Birds look upwards to avoid eagles. They should look down to avoid hunters.</i></span><br/>
-<span style='color:#60A0FF'>Decreases physical resistances by 20%</span><br/>
-<span style='color:green'>Damage increased by 60%</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:green'>New weapon special: marksman</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
+=== Greater Guardsman's Leather Armour &ndash; armour ===
+<span style='color:#808080'><i>A good guardsman never yields.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unyielding_.E2.80.93_resistance|unyielding]]</span><br/>
 <br/>
-=== Black Widow &ndash; amulet ===
-<span style='color:#808080'><i>That horrid thing corrupts the very air around us!</i></span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
+=== Guardsman's Leather Armour &ndash; armour ===
+<span style='color:#808080'><i>Loyalty will protect you like an expensive armour.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: steadfast</span><br/>
 <br/>
-=== Blackened Cloak &ndash; cloak ===
-<span style='color:#808080'><i>Under black skies, people start losing faith that the sun will ever rise.</i></span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+=== Heart of Ice &ndash; armour ===
+<span style='color:#808080'><i>Even warm smokes can bring frost. The sun is what we need.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>New weapon special: slow (ranged attacks only)</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
+<span style='color:purple'>New weapon special: slows (melee attacks only) (requires [[#Iced Boots_.E2.80.93_boots|Iced Boots]])</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#Chilling Touch_.E2.80.93_gauntlets|Chilling Touch]])</span><br/>
+<br/>
+=== Hell Warlord's Armour &ndash; armour ===
+<span style='color:#808080'><i>Abaddon ruled Inferno with an iron hand, but it did not stop his loyals from following him.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:green'>Increases all magical damages by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 40%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#warlord's rule_.E2.80.93_dummy|warlord's rule]]</span><br/>
+<br/>
+=== Hellforge Armour &ndash; armour ===
+<span style='color:#808080'><i>'Forge me an armour. I need to have forged armour to stop attacks armour stops.' - Abaddon</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 35%</span><br/>
+<br/>
+=== Hellforge Armour of Forging &ndash; armour ===
+<span style='color:#808080'><i>Forge weapons. Give the forgery to your enemies. They shall see that forged arsenal is not useful.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 35%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
 <br/>
-=== Blade Juggler &ndash; knife ===
-<span style='color:#808080'><i>He threw a dozen knives into the air, catching and throwing them one by one.</i></span><br/>
-<span style='color:green'>Damage decreased by 25%</span><br/>
-<span style='color:green'>100% (in EASY difficulty), 85% (in MEDIUM difficulty), 70% (in HARD difficulty) more attacks</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
-<br/>
-=== Blade of Turisas &ndash; sword ===
-<span style='color:#808080'><i>Every nation had its god of war. Or was it just one with many names?</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<br/>
-=== Blood Revenge &ndash; craftable as any armour ===
-<span style='color:#808080'><i>If you go spilling blood, make sure it is not your blood that would be spilled.</i></span><br/>
+=== Herod's Mithral Armour &ndash; armour ===
+<span style='color:#808080'><i>He was a poweful ruler, but he was not very righteous. No wonder that his cousin dethroned him.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 1 Topaz, 3 Opals, 4 Pearls and 1 Diamond</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (10)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#steals_.E2.80.93_dummy|steals]]</span><br/>
 <br/>
-=== Blooddrunk Beast &ndash; claws ===
-<span style='color:#808080'><i>Drink blood, it will keep you going in this hostile environment.</i></span><br/>
-<span style='color:#60A0FF'>Sucks 2 health from targets with each hit</span><br/>
+=== Hope of the Fallen &ndash; armour ===
+<span style='color:#808080'><i>Dark immortality is encased in great sadness, but the encasement has its flaws.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce decreased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold decreased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 35%</span><br/>
+<br/>
+=== Horrid Ice Armour &ndash; armour ===
+<span style='color:#808080'><i>Frost not only causes you cold feet, it also kills a peasant's crops, veggies and culinary weed.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
+<br/>
+=== Hunter of Kings &ndash; armour ===
+<span style='color:#808080'><i>Nobody knows who he was. Nobody knows where he came from. Nobody knows how to stop him.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 25%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#frail tide (INTENSITY)_.E2.80.93_resistance|frail tide (30)]]</span><br/>
+<span style='color:purple'>New ability: conviction (20) (requires [[#Legion Slayer_.E2.80.93_cloak|Legion Slayer]])</span><br/>
+<br/>
+=== Ice Armour &ndash; armour ===
+<span style='color:#808080'><i>Dwarvish runes can prevent ice from melting.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
+<br/>
+=== Ice Armour of Health &ndash; armour ===
+<span style='color:#808080'><i>Hot weather is bad for health.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
+<span style='color:#60A0FF'>5 more hitpoints per level per level</span><br/>
+<br/>
+=== Iron Armour &ndash; armour ===
+<span style='color:#808080'><i>When choosing between a hundred warriors clad in iron and fifty warriors clad in mithril, choose iron.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Iron Armour of the Friendly General &ndash; armour ===
+<span style='color:#808080'><i>I will not let you die, my protégé.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#shield (INTENSITY)_.E2.80.93_resistance|shield (20)]]</span><br/>
+<br/>
+=== Iron Armour of Thorns &ndash; armour ===
+<span style='color:#808080'><i>Do you think that you can attack me and leave uninjured?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#thorns_.E2.80.93_dummy|thorns]]</span><br/>
+<br/>
+=== Iron Sentinel &ndash; armour ===
+<span style='color:#808080'><i>If the defender cannot stop the attacks, he has to kill the enemies before they hurt him.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:green'>Enemy resistances to pierce decreased by 20%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Leather Armour &ndash; armour ===
+<span style='color:#808080'><i>I know that it is cheap, but it does not slow me down.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<br/>
+=== Lethalia's Armour &ndash; armour ===
+<span style='color:#808080'><i>Tinebrithiel's survives forever.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:purple'>5% to all base resistances (requires [[#Lethalia's Staff_.E2.80.93_staff|Lethalia's Staff]])</span><br/>
+<br/>
+=== Lionheart &ndash; armour ===
+<span style='color:#808080'><i>Lions spend twenty hours per day slacking. Yet they are a symbol of bravery. Like our nobles.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
+<br/>
+=== Marilyn's Armour &ndash; armour ===
+<span style='color:#808080'><i>A manly man can have a woman's name without being funny.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>24 more hitpoints per level</span><br/>
+<br/>
+=== Mithral Armour &ndash; armour ===
+<span style='color:#808080'><i>This highly valuable armour is told to be made by dwarvish apprentices. I wonder what their masters make.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Mithral Armour of Wrath &ndash; armour ===
+<span style='color:#808080'><i>Forged for the elite among Dwarvish Berserkers.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<br/>
+=== Morok's Armour &ndash; armour ===
+<span style='color:#808080'><i>Fear the one who calls himself a god of war.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 17%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Mystic Armour &ndash; armour ===
+<span style='color:#808080'><i>Forged at unknown location who knows when.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Mystic Armour of the Untouchable &ndash; armour ===
+<span style='color:#808080'><i>Body count matters. I will better let that evasive and well armoured warrior for others.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Mystic Occult Armour of Carpathia &ndash; armour ===
+<span style='color:#808080'><i>Psychospiritual mysticism leads to nocturnal blackness.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Mystic Occult Armour of Carpathia &ndash; armour ===
+<span style='color:#808080'><i>Psychospiritual mysticism leads to nocturnal blackness.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Prismatic Iron Armour &ndash; armour ===
+<span style='color:#808080'><i>This armour was made to kill wizards, so do not expect it to save you from deadly blades.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Redshirt Armour &ndash; armour ===
+<span style='color:#808080'><i>Why do they all try to kill that man?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
+<br/>
+=== Rherraent's Armour &ndash; armour ===
+<span style='color:#808080'><i>Shiny armour will only attract unwanted attention.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#Rherraent's Sword_.E2.80.93_sword|Rherraent's Sword]])</span><br/>
+<span style='color:purple'>3% to all resistances (requires [[#Rherraent's Helm_.E2.80.93_helm|Rherraent's Helm]])</span><br/>
+<span style='color:purple'>3% to all resistances (requires [[#Rherraent's Ring_.E2.80.93_ring|Rherraent's Ring]])</span><br/>
+<br/>
+=== Runner's Leather Armour &ndash; armour ===
+<span style='color:#808080'><i>Running is always better without heavy armour.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<br/>
+=== Shadows of Deception &ndash; armour ===
+<span style='color:#808080'><i>So much energy spent on nothing. A good spend.</i></span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#antimagic (INTENSITY)_.E2.80.93_resistance|antimagic (35)]]</span><br/>
+<br/>
+=== Shroud of Iron &ndash; armour ===
+<span style='color:#808080'><i>Those armours are not very good, but if you wear more of them at the same time...</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 26%</span><br/>
+<span style='color:green'>Damage decreased by 1</span><br/>
+<span style='color:green'>1 fewer attacks</span><br/>
+<span style='color:#60A0FF'>2 fewer movement points</span><br/>
+<br/>
+=== The Generous Armour &ndash; armour ===
+<span style='color:#808080'><i>Hey there, you are a bad fighter, wear this.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#producer_.E2.80.93_dummy|producer]]</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== The Noble Survivor &ndash; armour ===
+<span style='color:#808080'><i>He wishes that all the nobility could be hung with the guts of priests. That will not work on me.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 35%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leeches_.E2.80.93_dummy|leech]]</span><br/>
+<span style='color:#60A0FF'>New ability: submerge</span><br/>
+<br/>
+=== The Parasite &ndash; armour ===
+<span style='color:#808080'><i>They make promises of the impossible.
+They say they guide you to reach the impossible.
+They pretend you had reached the impossible.
+If you do not believe them, you did it wrong.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>2 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#parasite_.E2.80.93_dummy|parasite]]</span><br/>
+<br/>
+=== The Unraveller &ndash; armour ===
+<span style='color:#808080'><i>A mummy cannot be stopped. If it is tangled, it will just unravel the tangled parts.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>3 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#resistant to slow_.E2.80.93_dummy|resistant to slow]]</span><br/>
+<br/>
+=== Unsung Odes &ndash; armour ===
+<span style='color:#808080'><i>Your deeds of valour will not be revered forever. But their consequences will not vanish.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Unseen Writings_.E2.80.93_cloak|Unseen Writings]])</span><br/>
+<span style='color:purple'>4% to all physical resistances (requires [[#Unspoken Words_.E2.80.93_gauntlets|Unspoken Words]])</span><br/>
+<span style='color:purple'>4% to magical resistances (requires [[#Unthought Memories_.E2.80.93_amulet|Unthought Memories]])</span><br/>
+<br/>
+=== Vanquisher's Mithral Armour &ndash; armour ===
+<span style='color:#808080'><i>Like a tempest, he landed on his enemies, gore flying everywhere. Even his armour helped him spill blood.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Damage increased by 30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Vinegar Bath &ndash; armour ===
+<span style='color:#808080'><i>Bathe bones in vinegar, they will soften and will bend rather than break.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 35%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Violent Mage's Armour &ndash; armour ===
+<span style='color:#808080'><i>As a heavyweight chessboxing champion, he adjusted his techniques to fit both of his talents.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:purple'>20% increased damage with violent beatdown (requires [[#Violent Mage's Cloak_.E2.80.93_cloak|Violent Mage's Cloak]])</span><br/>
+<br/>
+=== Void &ndash; armour ===
+<span style='color:#808080'><i>Try to cut through this. There is nothing inside, my guts are in another dimension!</i></span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 25%</span><br/>
+<br/>
+== axe ==
+=== Axe of Perun &ndash; axe ===
+<span style='color:#808080'><i>Perun's axe smote the wicked with thundering rage.</i></span><br/>
+<span style='color:green'>Damage increased by 55% (in EASY difficulty), 35% (in MEDIUM difficulty), 15% (in HARD difficulty)</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<br/>
+=== Barbaric Glory &ndash; axe ===
+<span style='color:#808080'><i>Abandon the order, attack them randomly when unprepared.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 45% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+<br/>
+=== Bringer of Fragility &ndash; axe ===
+<span style='color:#808080'><i>How can a weapon and armour this heavy be so ineffective?!</i></span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (15)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (10)]]</span><br/>
+<br/>
+=== Deathblade Inheritance &ndash; axe ===
+<span style='color:#808080'><i>It might not hit hard, but it will bring you reinforcements.</i></span><br/>
+<span style='color:green'>40% (in EASY difficulty), 35% (in MEDIUM difficulty), 30% (in HARD difficulty) more attacks</span><br/>
+<span style='color:green'>Sets damage type to blade</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Deathblade)]]</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<br/>
+=== Executioner's Axe &ndash; axe ===
+<span style='color:#808080'><i>A good executioner kills with a single blow.</i></span><br/>
+<span style='color:green'>Merges attacks</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
+<span style='color:#60A0FF'>Sets alignment to neutral</span><br/>
+<br/>
+=== Fowleri's Chopper &ndash; axe ===
+<span style='color:#808080'><i>He broke her heart. No, wait, not heart, sanity. He broke her sanity.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 15% (in EASY difficulty), 5% (in MEDIUM difficulty), -5% (in HARD difficulty)</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
 <span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
-=== Bloodsucker's Potion &ndash; potion ===
-<span style='color:#808080'><i>All this blood. It is yours. You will drink it. You will guzzle it. You will choke on it. You will drown in it.</i></span><br/>
-<span style='color:green'>New weapon special (ranged attacks only): drain</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#blood drinking_.E2.80.93_dummy|blood drinking]]</span><br/>
+=== Headsmasher &ndash; axe ===
+<span style='color:#808080'><i>'Let us give the orcs something they like, maybe they will let us be.'
+'What do they like?'
+'Smashing heads.'</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:green'>60% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
 <br/>
-=== Blue orb of dragonflame &ndash; limited ===
-<span style='color:#808080'><i>'Have you ever seen something like this?'
-'No, I will never see anything like this.'</i></span><br/>
-<span style='color:green'>2 more attacks</span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
+=== Iridium &ndash; axe ===
+<span style='color:#808080'><i>Mages hypothetise that there is an extremely heavy metal that its ore's weight pulls it into depths.</i></span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 40% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>Damage increased by 4</span><br/>
+<span style='color:green'>Enemy resistances to blade decreased by 15%</span><br/>
 <br/>
-=== Book of Courage &ndash; limited ===
-<span style='color:#808080'><i>Daniel was looking for this book. But it was in a dark corner.</i></span><br/>
-<span style='color:green'>Unit becomes fearless</span><br/>
+=== Lake of Blood &ndash; axe ===
+<span style='color:#808080'><i>Liquids soak into the ground. To fill a lake, you have to gather liquids fast.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
 <br/>
-=== Book of Fireballs &ndash; limited ===
-<span style='color:#808080'><i>Burn, incinerate, scorch, see your foes turn to ash.</i></span><br/>
-<span style='color:orange'>New advancements: Casting fireballs, from basic casting to explosive damages</span><br/>
+=== Lethal Axe &ndash; axe ===
+<span style='color:#808080'><i>Girls went chopping for revenge. One of them prepared herself quite well.</i></span><br/>
+<span style='color:green'>Damage increased by 45%</span><br/>
+<span style='color:green'>35% more attacks</span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
+<span style='color:purple'>10% more overall damage (requires [[#Lethal staff_.E2.80.93_staff|Lethal Staff]])</span><br/>
 <br/>
-=== Book of Herbal Tinctures and Malignancies &ndash; limited ===
-<span style='color:#808080'><i>Like real cures are not needed to get payment for healing, real poison is not needed to harm.</i></span><br/>
-<span style='color:orange'>New advancements: Poisons and cures</span><br/>
+=== Lilith's Precious &ndash; axe ===
+<span style='color:#808080'><i>In order to be able to fight with any weapon available, Lilith swaps weapon types once per century.</i></span><br/>
+<span style='color:green'>Damage increased by 15% (in EASY difficulty), 5% (in MEDIUM difficulty), -5% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: charge</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
 <br/>
-=== Book of Magical Swordplay &ndash; limited ===
-<span style='color:#808080'><i>It is not strength or motivation that makes a great warrior. It is the skill.</i></span><br/>
-<span style='color:orange'>New advancements: Fencing techniques, offensive and also defensive</span><br/>
+=== Morrígan's Slasher &ndash; axe ===
+<span style='color:#808080'><i>Why do these heathens believe that there can be a <b>goddess</b> of war?</i></span><br/>
+<span style='color:green'>Damage increased by 50%</span><br/>
+<span style='color:green'>Damage increased by 3</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
+<br/>
+=== Silver Axe &ndash; axe ===
+<span style='color:#808080'><i>Good metal is better than flashy magic.</i></span><br/>
+<span style='color:green'>Damage increased by 35%</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<br/>
+=== The Grim Butcher &ndash; axe ===
+<span style='color:#808080'><i>Pigs, goats, men... is there a difference? They all taste the same.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#evisceration_.E2.80.93_dummy|evisceration]]</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<br/>
+=== Unholy Axe &ndash; axe ===
+<span style='color:#808080'><i>Use the lightbeam spell. It kills anything unholy enough.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens_.E2.80.93_illuminates|darkens]]</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+<br/>
+=== Winged Axe &ndash; axe ===
+<span style='color:#808080'><i>Each day, he fought bravely in distant lands. Every night, he enjoyed his time with his wife.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
+<span style='color:#60A0FF'>Sets alignment to neutral</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>New ability: teleport</span><br/>
+<br/>
+=== Zealous Axe &ndash; axe ===
+<span style='color:#808080'><i>Let them try to attack us for we shall be those who strike first.</i></span><br/>
+<span style='color:green'>Damage increased by 45%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#zeal aura_.E2.80.93_dummy|zeal aura]]</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+== boots ==
+=== Bones of Steel &ndash; boots ===
+<span style='color:#808080'><i>A magical device with no detected magical activity.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 20%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:purple'>2 to base damage (requires [[#Hydraulic Core_.E2.80.93_amulet|Hydraulic Core]])</span><br/>
 <br/>
 === Boots of Evanescence &ndash; boots ===
 <span style='color:#808080'><i>Now you see me. Now you don't.</i></span><br/>
@@ -304,10 +681,159 @@ traditions were brought to them.</i></span><br/>
 === Boots of Foolish Fighters &ndash; boots ===
 <span style='color:#808080'><i>Run fast, hit hard.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage increased by 2 (melee attacks only)</span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
 <span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
+=== Crushing Walk &ndash; boots ===
+<span style='color:#808080'><i>Sometimes I am not looking where I step and the casualties can be significant.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Sets damage type to impact</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Eidolon's Boots &ndash; boots ===
+<span style='color:#808080'><i>His champion in shining armour faced evils for centuries, often together with his children. The land became prosperous.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
+<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
+<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
+<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
+<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
+<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
+<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
+<span style='color:purple'>New ability: Wardrums (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
+<br/>
+=== Elusive Boots &ndash; boots ===
+<span style='color:#808080'><i>Enemies are blocking the way? Who cares?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 2%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
+<br/>
+=== Fit for Speed &ndash; boots ===
+<span style='color:#808080'><i>The best runners are too thin to fight.</i></span><br/>
+<span style='color:green'>Damage decreased by 70% (in EASY difficulty), 80% (in MEDIUM difficulty), 90% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>4 more movement points</span><br/>
+<br/>
+=== Flying Boots &ndash; boots ===
+<span style='color:#808080'><i>He could run through caves and hills like on a plain road. He could even walk on water.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 7%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on flat terrains set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through villages set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through castles set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs in shallow waters set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on coastal reefs set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs in deep waters set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through swampy places set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs across sands set to 1</span><br/>
+<br/>
+=== Iced Boots &ndash; boots ===
+<span style='color:#808080'><i>When flames fall from the skies or spring from the ground, hot days are not what you should fear.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:purple'>Movement increased by 1 (requires [[#Heart of Ice_.E2.80.93_armour|Heart of Ice]])</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#Chilling Touch_.E2.80.93_gauntlets|Chilling Touch]])</span><br/>
+<br/>
+=== Merciless Wake &ndash; boots ===
+<span style='color:#808080'><i>Why so much hurry? Go slowly, look around, contemplate, kill whatever you like...</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Damage increased by 5</span><br/>
+<span style='color:#60A0FF'>2 fewer movement points</span><br/>
+<br/>
+=== Mountain Trek &ndash; boots ===
+<span style='color:#808080'><i>'It will take us months to pass through these mountains!'
+'I will wait for you on the other side.'</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on mountains set to 1</span><br/>
+<br/>
+=== Path of Perpetual Torment &ndash; boots ===
+<span style='color:#808080'><i>Cursed to fight the unholy without respite.</i></span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#unholybane_.E2.80.93_damage|unholybane]]</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 15%</span><br/>
+<span style='color:#60A0FF'>2 fewer movement points</span><br/>
+<span style='color:#60A0FF'>Sets alignment to lawful</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
+<br/>
+=== Search for Wisdom &ndash; boots ===
+<span style='color:#808080'><i>They look for wisdom. But that is a fool's errand, it never existed.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#Wisdom of the Ages_.E2.80.93_helm|Wisdom of the Ages]])</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#Tracking the Lost Knowledge_.E2.80.93_cloak|Tracking the Lost Knowledge]])</span><br/>
+<br/>
+=== Slow Boots &ndash; boots ===
+<span style='color:#808080'><i>If you cannot outrun the knights, why do you even try?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Slow Boots of Certainty &ndash; boots ===
+<span style='color:#808080'><i>I could have been here yesterday, but it was not worth the danger.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Steps to Perdition &ndash; boots ===
+<span style='color:#808080'><i>I agree that you are effective, but it still leads to disaster - one accident and you are dead.</i></span><br/>
+<span style='color:#60A0FF'>Decreases physical resistances by 20% (in EASY difficulty), 25% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Damage increased by 20% (in EASY difficulty), 15% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:green'>Enemy resistances to blade decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to impact decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<br/>
+=== Taxes &ndash; boots ===
+<span style='color:#808080'><i>Legends speak of a man who took from the poor and gave to the rich.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>3 more movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#tax collector_.E2.80.93_dummy|tax collector]]</span><br/>
+<br/>
+=== Taxes &ndash; boots ===
+<span style='color:#808080'><i>Legends speak of a man who took from the poor and gave to the rich.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>3 more movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#tax collector_.E2.80.93_dummy|tax collector]]</span><br/>
+<br/>
+=== The Pit Dweller &ndash; boots ===
+<span style='color:#808080'><i>Darkness is where he stays.</i></span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
+<br/>
+=== The Practical Boots &ndash; boots ===
+<span style='color:#808080'><i>Your footwear dictates your mobility and protects you from environment. Avoid any sacrifices for style or comfort.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>8 more hitpoints per level</span><br/>
+<br/>
+=== The Southern Boots &ndash; boots ===
+<span style='color:#808080'><i>Boots are impractical in hot weather? We shall see about that!</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
+<span style='color:#60A0FF'>Movement costs across sands set to 1</span><br/>
+<br/>
+=== Wanderlust &ndash; boots ===
+<span style='color:#808080'><i>See far. Go far. Know the beauty of the world.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Increases all magical damages by 5%</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<br/>
+== bow ==
 === Bow of Many Arrows &ndash; bow ===
 <span style='color:#808080'><i>There must be a thousand archers over there, but I see only one!</i></span><br/>
 <span style='color:green'>40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
@@ -327,85 +853,116 @@ traditions were brought to them.</i></span><br/>
 <span style='color:green'>Increases all magical damages by 10%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#cantor_.E2.80.93_dummy|cantor]]</span><br/>
 <br/>
-=== Brawler's Triumph &ndash; gauntlets ===
-<span style='color:#808080'><i>It protects well... but not as much from punches.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<br/>
-=== Brightslash &ndash; sword ===
-<span style='color:#808080'><i>He came like a shining star,
-allied with the sun,
-he smote the villains,
-and saved the righteous.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (2)_.E2.80.93_dummy|absorbs (2)]]</span><br/>
-<span style='color:#60A0FF'>New ability: cures</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#regenerates (VALUE)_.E2.80.93_regenerate|regenerates (16)]]</span><br/>
-<br/>
-=== Bringer of Fragility &ndash; axe ===
-<span style='color:#808080'><i>How can a weapon and armour this heavy be so ineffective?!</i></span><br/>
+=== Coward's Bow &ndash; bow ===
+<span style='color:#808080'><i>I am using a bow because I hate being hit. I even have a bow made specially for me.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
 <span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (15)]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (10)]]</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
 <br/>
-=== Caeordwyccywyrin's Spear &ndash; spear ===
-<span style='color:#808080'><i>Whose spear is this?</i></span><br/>
-<span style='color:green'>Damage increased by 4</span><br/>
-<span style='color:green'>40% more attacks</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
+=== Dragonslayer &ndash; bow ===
+<span style='color:#808080'><i>He killed dragons with his legendary bow, but he was no match for saurians.</i></span><br/>
+<span style='color:green'>Damage increased by 35%</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misdraconia_.E2.80.93_damage|misdraconia]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
 <br/>
-=== Chaos &ndash; craftable as any armour ===
-<span style='color:#808080'><i>What had the creator of this in mind when he was designing?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
-<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 2 Topazes, 1 Opal, 1 Diamond, 4 Emeralds, 2 Sapphires and 1 Black Pearl</span><br/>
-<br/>
-=== Chaosbringer &ndash; dagger ===
-<span style='color:#808080'><i>Do you like order? Shame that I do not.</i></span><br/>
-<span style='color:green'>40% more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misanthropia_.E2.80.93_damage|misanthropia]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misnania_.E2.80.93_damage|misnania]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misdryadia_.E2.80.93_damage|misdryadia]]</span><br/>
-<br/>
-=== Chilling Touch &ndash; gauntlets ===
-<span style='color:#808080'><i>Unnatural clouds of dust can come and cover the sun. No heat will come and summer crops will be touched by chill.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage decreased by 3</span><br/>
+=== Fine bow &ndash; bow ===
+<span style='color:#808080'><i>Precision is more important than anything else.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:purple'>New ability: freezing aura (requires [[#Heart of Ice_.E2.80.93_armour|Heart of Ice]])</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#Iced Boots_.E2.80.93_boots|Iced Boots]])</span><br/>
 <br/>
-=== Chu-ko-nu &ndash; xbow ===
-<span style='color:#808080'><i>Do you even reload that thing?</i></span><br/>
-<span style='color:green'>Damage increased by 15%</span><br/>
-<span style='color:green'>55% more attacks</span><br/>
-<span style='color:green'>New weapon special: marksman</span><br/>
+=== Heavy Bow &ndash; bow ===
+<span style='color:#808080'><i>Fellows, what would you say if I made a bow that shoots spears?</i></span><br/>
+<span style='color:green'>Damage increased by 120% (in EASY difficulty), 100% (in MEDIUM difficulty), 80% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% fewer attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#pierce_.E2.80.93_dummy|pierce]]</span><br/>
 <br/>
-=== Claymore &ndash; sword ===
-<span style='color:#808080'><i>I am done with you, go away!</i></span><br/>
+=== Poisonous Bow &ndash; bow ===
+<span style='color:#808080'><i>Please stop focusing on one enemy.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:green'>35% more attacks</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<br/>
+=== Stormforce &ndash; bow ===
+<span style='color:#808080'><i>Is that the fabled Stormforce? I thought it was just a legend!</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
+<br/>
+=== Stormforce &ndash; bow ===
+<span style='color:#808080'><i>Is that the fabled Stormforce? I thought it was just a legend!</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
+<br/>
+=== The Outcast &ndash; bow ===
+<span style='color:#808080'><i>Loneliness will teach you to stop relying on others. It makes you free if you pay its price.</i></span><br/>
 <span style='color:green'>Damage increased by 10%</span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#knockback_.E2.80.93_damage|knockback]]</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<br/>
+=== The Predator &ndash; bow ===
+<span style='color:#808080'><i>Try not to split from the group.</i></span><br/>
+<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#lurk_.E2.80.93_damage|lurk]]</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== The Unrepenting &ndash; bow ===
+<span style='color:#808080'><i>I have broken the sacred vow, forgotten the pledge of allegiance, lost my faith.
+I did what I did. I cannot change it, so why should I torment myself with it?</i></span><br/>
+<span style='color:green'>Damage increased by 5 (in EASY difficulty), 4 (in MEDIUM difficulty), 3 (in HARD difficulty)</span><br/>
+<span style='color:green'>40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#distant attack_.E2.80.93_attacks|distant attack]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#hit and run_.E2.80.93_dummy|hit and run]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#anathema_.E2.80.93_leadership|anathema]]</span><br/>
+<br/>
+== claws ==
+=== Blooddrunk Beast &ndash; claws ===
+<span style='color:#808080'><i>Drink blood, it will keep you going in this hostile environment.</i></span><br/>
+<span style='color:#60A0FF'>Sucks 2 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+== cloak ==
+=== Acantha's Cloak &ndash; cloak ===
+<span style='color:#808080'><i>She was forced to abandon politics and care about children. She indoctrinated them with evil.</i></span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<br/>
+=== Beyond the Grasp of Men &ndash; cloak ===
+<span style='color:#808080'><i>Fast, evasive and seeing further than most. No man shall catch the unreachable.</i></span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 15%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Blackened Cloak &ndash; cloak ===
+<span style='color:#808080'><i>Under black skies, people start losing faith that the sun will ever rise.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
 <br/>
 === Cloak of Burning Retribution &ndash; cloak ===
 <span style='color:#808080'><i>You spat on the ground at my feet? I will set your house on fire!</i></span><br/>
-<span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
 <br/>
 === Cloak of Koschei &ndash; cloak ===
 <span style='color:#808080'><i>Koschei made it so far on the path of immortality, yet one silly mistake happened to be fatal.</i></span><br/>
 <span style='color:green'>New weapon special: plague (melee attacks only)</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
 <span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
 <span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
@@ -422,95 +979,618 @@ and saved the righteous.</i></span><br/>
 === Cloak of the Pale Rider &ndash; cloak ===
 <span style='color:#808080'><i>Do not fear death if it is not near you.</i></span><br/>
 <span style='color:green'>Damage increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 7%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 7%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 7%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 20%</span><br/>
 <span style='color:purple'>+12 to hitpoints (requires [[#Angel of Death's Ring_.E2.80.93_ring|Angel of Death's Ring]])</span><br/>
 <span style='color:purple'>5% to all resistances (requires [[#Amulet of the Last Guide_.E2.80.93_amulet|Amulet of the Last Guide]])</span><br/>
 <br/>
-=== Colossally Colossal Arch-Devilish Blade of Universal Annihilation &ndash; sword ===
-<span style='color:#808080'><i>Forged by the Paladin of Golden Glory with the Hammer of Eternal Magic.</i></span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>Enemy resistances to blade decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: aura of power</span><br/>
+=== Eidolon's Coat &ndash; cloak ===
+<span style='color:#808080'><i>He, a being of darkness, studied the art of white mages for generations. He learned the powers of light.</i></span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>New ability: cures</span><br/>
+<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
+<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
+<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
+<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
+<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
+<span style='color:purple'>New ability: Absorbs (1) (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
 <br/>
-=== Corpsegrinder &ndash; spear ===
-<span style='color:#808080'><i>Mutilating dead enemies makes you forget your woes.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#evisceration_.E2.80.93_dummy|evisceration]]</span><br/>
+=== Legion Slayer &ndash; cloak ===
+<span style='color:#808080'><i>Nobody knows how he works. Nobody knows when he strikes. Nobody lives to tell how he looks.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#penetrates_.E2.80.93_dummy|penetrates]]</span><br/>
+<span style='color:purple'> 2 more movement points (requires [[#Hunter of Kings_.E2.80.93_armour|Hunter of Kings]])</span><br/>
 <br/>
-=== Coward's Bow &ndash; bow ===
-<span style='color:#808080'><i>I am using a bow because I hate being hit. I even have a bow made specially for me.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
+=== Nocturnal Cloak &ndash; cloak ===
+<span style='color:#808080'><i>You merely adopted darkness, I was molded by it.</i></span><br/>
+<span style='color:green'>New weapon special: backstab (melee attacks only)</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
 <br/>
-=== Crapsack World &ndash; amulet ===
-<span style='color:#808080'><i>'Oh, almighty god, why did you create this world?'
-'It was not me. I have a perfect alibi, by the way.'</i></span><br/>
+=== Paranoia &ndash; cloak ===
+<span style='color:#808080'><i>Every face is an enemy.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#forsaken_.E2.80.93_resistance|forsaken]]</span><br/>
+<br/>
+=== Pyromancer's Cloak &ndash; cloak ===
+<span style='color:#808080'><i>When his body was destroyed, he rose again from the ashes.</i></span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:purple'>5% to magical resistances (requires [[#Pyromancer's Sword_.E2.80.93_sword|Pyromancer's Sword]])</span><br/>
+<span style='color:purple'>New ability: from the ashes (requires [[#Pyromancer's Ring_.E2.80.93_ring|Pyromancer's Ring]])</span><br/>
+<br/>
+=== Robes of Filth &ndash; cloak ===
+<span style='color:#808080'><i>You call my new shirt filth?! For the thirty dirty pins in the sleeves?</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 15%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#infect_.E2.80.93_poison|infect]] (melee attacks only)</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+<br/>
+=== The Deadborn &ndash; cloak ===
+<span style='color:#808080'><i>Darkest legends tell of necromancers creating undead so pure that they were never tainted by life, dead from birth.</i></span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<br/>
+=== The gloomy Cloak &ndash; cloak ===
+<span style='color:#808080'><i>Bring sadness to your enemies by showing them how slow they are.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#The gloomy Ring_.E2.80.93_ring|The gloomy Ring]])</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#The gloomy Amulet_.E2.80.93_amulet|The gloomy Amulet]])</span><br/>
+<br/>
+=== The Grey Cloak &ndash; cloak ===
+<span style='color:#808080'><i>It somewhat reminds me of Gundolf the Great.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Damage increased by 10%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to blade decreased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== The Ragtag Misfit &ndash; cloak ===
+<span style='color:#808080'><i>All I want is your love... Yes, I know I will get no love, but I will get your gold at least.</i></span><br/>
 <span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#steals_.E2.80.93_dummy|steals]]</span><br/>
+<br/>
+=== The Touch of God &ndash; cloak ===
+<span style='color:#808080'><i>'I... I have been touched by god.'
+'Touched by our almightly lord and saviour?'
+'No, by lord Cthulhu.'</i></span><br/>
+<span style='color:#60A0FF'>Decreases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (40)]]</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== The Touch of God &ndash; cloak ===
+<span style='color:#808080'><i>'I... I have been touched by god.'
+'Touched by our almightly lord and saviour?'
+'No, by lord Cthulhu.'</i></span><br/>
+<span style='color:#60A0FF'>Decreases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (40)]]</span><br/>
+<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<br/>
+=== Tracking the Lost Knowledge &ndash; cloak ===
+<span style='color:#808080'><i>If it has been lost, then it must had been created before. Maybe it was never created.</i></span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:purple'>New ability: absorb (1) (requires [[#Wisdom of the Ages_.E2.80.93_helm|Wisdom of the Ages]])</span><br/>
+<span style='color:purple'>New base ranged weapon special: horrid (requires [[#Search for Wisdom_.E2.80.93_boots|Search for Wisdom]])</span><br/>
 <br/>
-=== Creepy Potion &ndash; potion ===
-<span style='color:#808080'><i>If you hear me better fear me, if you see me better flee me.</i></span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (20)]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
+=== Transformed Flesh &ndash; cloak ===
+<span style='color:#808080'><i>Some barbarian civilisations could achieve great inventions without magic.</i></span><br/>
+<span style='color:purple'>5% better defence on all terrains (requires [[#Hydraulic Core_.E2.80.93_amulet|Hydraulic Core]])</span><br/>
+<span style='color:purple'>5% better defence on all terrains (requires [[#Mind Assisting Element_.E2.80.93_helm|Mind Assisting Element]])</span><br/>
 <br/>
-=== Crown of the King &ndash; helm ===
-<span style='color:#808080'><i>The masses obeyed the one who had the crown. Whoever it was.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+=== Unseen Writings &ndash; cloak ===
+<span style='color:#808080'><i>No matter how well you write, after a millenium there will be nothing of it. Though copies may survive.</i></span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 5%</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 5%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:purple'>4% to magical resistances (requires [[#Unspoken Words_.E2.80.93_gauntlets|Unspoken Words]])</span><br/>
+<span style='color:purple'>New base ranged weapon special: struggle (requires [[#Unthought Memories_.E2.80.93_amulet|Unthought Memories]])</span><br/>
+<span style='color:purple'>4% to all physical resistances (requires [[#Unsung Odes_.E2.80.93_armour|Unsung Odes]])</span><br/>
+<br/>
+=== Violent Mage's Cloak &ndash; cloak ===
+<span style='color:#808080'><i>After many brawls, he decided to use his magic to improve his brawling abilities.</i></span><br/>
 <span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:purple'>New Ability: cantor (requires [[#Ring of the King_.E2.80.93_ring|Ring of the King]])</span><br/>
-<span style='color:purple'>+1 to base attacks (requires [[#Armour of the King_.E2.80.93_armour|Armour of the King]])</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#Sceptre of the King_.E2.80.93_mace|Sceptre of the King]])</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<span style='color:purple'>20% increased damage with violent beatdown (requires [[#Violent Mage's Armour_.E2.80.93_armour|Violent Mage's Armour]])</span><br/>
 <br/>
-=== Crushing Walk &ndash; boots ===
-<span style='color:#808080'><i>Sometimes I am not looking where I step and the casualties can be significant.</i></span><br/>
+=== Woodland Cloak &ndash; cloak ===
+<span style='color:#808080'><i>Where is the elf wearing that green cloak? Has anybody seen him?</i></span><br/>
+<span style='color:#60A0FF'>New ability: ambush</span><br/>
+<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
+<br/>
+=== Worshipper of Darkness &ndash; cloak ===
+<span style='color:#808080'><i>Worshipping the heralds of Light is a heavy burden people think to be pleasant to carry.</i></span><br/>
+<span style='color:green'>Damage decreased by 2</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#Deathaura_.E2.80.93_heals|deathaura (8)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (10)]]</span><br/>
+<br/>
+== craftable as any armour ==
+=== Blood Revenge &ndash; craftable as any armour ===
+<span style='color:#808080'><i>If you go spilling blood, make sure it is not your blood that would end up spilled.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Sets damage type to impact</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:green'>Damage increased by 35% (in EASY difficulty), 30% (in MEDIUM difficulty), 25% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 1 Topaz, 3 Opals, 4 Pearls and 1 Diamond</span><br/>
 <br/>
-=== Cunctator's Armour &ndash; armour ===
-<span style='color:#808080'><i>Enemies were bored to death when Cunctator finally attacked.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 22%</span><br/>
+=== Chaos &ndash; craftable as any armour ===
+<span style='color:#808080'><i>What had the creator of this in mind when he was designing?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
+<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 2 Topazes, 1 Opal, 1 Diamond, 4 Emeralds, 2 Sapphires and 1 Black Pearl</span><br/>
+<br/>
+=== Defensive Stance &ndash; craftable as any armour ===
+<span style='color:#808080'><i>A good defence is the best offence.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20% (in EASY difficulty), 15% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: steadfast</span><br/>
 <span style='color:#60A0FF'>2 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#shield (INTENSITY)_.E2.80.93_resistance|shield (20)]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#antisocial_.E2.80.93_leadership|antisocial]]</span><br/>
-<span style='color:purple'>5% to all resistances (requires [[#Cunctator's sword_.E2.80.93_sword|Cunctator's Sword]])</span><br/>
-<span style='color:purple'>5% to all resistances (requires [[#Cunctator's Helmet_.E2.80.93_helm|Cunctator's Helmet]])</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians and 2 Topazes</span><br/>
 <br/>
-=== Cunctator's Helmet &ndash; helm ===
-<span style='color:#808080'><i>If you command Cunctator to attack immediately, he will not obey.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage decreased by 10% (in EASY difficulty), 20% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+=== Deflector of Light &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Drive all light away and enjoy the darkness.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens severely_.E2.80.93_illuminates|darkens severely]]</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 4 Obsidians, 2 Topazes, 1 Opal, 3 Diamonds, 1 Ruby and 1 Emerald</span><br/>
+<br/>
+=== Dugi's Ward &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Metal is the best, especially if it's heavy enough.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
+<span style='color:green'>Damage increased by 15%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (3)_.E2.80.93_dummy|absorbs (3)]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 2 Topazes, 2 Opals, 2 Pearls, 2 Diamonds, 2 Rubies, 4 Emeralds, 4 Amethysts, 4 Sapphires and 4 Black Pearls</span><br/>
+<br/>
+=== Dying Dreams &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Have you ever dreamed of defeating me? Feel your weakness and see me recovering from everything.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leeches_.E2.80.93_dummy|leech]]</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (15)]]</span><br/>
-<span style='color:purple'>New ability: careful (10) (requires [[#Cunctator's sword_.E2.80.93_sword|Cunctator's Sword]])</span><br/>
-<span style='color:purple'>New ability: 10% to physical resistances (requires [[#Cunctator's Armour_.E2.80.93_armour|Cunctator's Armour]])</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 2 Topazes, 2 Diamonds, 3 Rubies and 1 Emerald</span><br/>
 <br/>
-=== Cunctator's sword &ndash; sword ===
-<span style='color:#808080'><i>Nobody wanted to face Cunctator. He never fought when you wanted to fight him.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
+=== Hatred &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Arm yourself with hatred, your lacking skill will not matter.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Damage increased by 8 (in EASY difficulty), 7 (in MEDIUM difficulty), 6 (in HARD difficulty)</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 2 Topazes, 1 Opal, 1 Amethyst, 2 Sapphires and 1 Black Pearl</span><br/>
+<br/>
+=== Intoxicator &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Orcish legends talk about a poison so potent that it debilitates its victims instantly.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:green'>Damage increased by 10%</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
 <span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#explosive slow_.E2.80.93_damage|explosive slow]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#hit and run_.E2.80.93_dummy|hit and run]]</span><br/>
-<span style='color:purple'>New melee weapon special: struggle (requires [[#Cunctator's Armour_.E2.80.93_armour|Cunctator's Armour]])</span><br/>
-<span style='color:purple'>5% to all magical resistances (requires [[#Cunctator's Helmet_.E2.80.93_helm|Cunctator's Helmet]])</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to poison_.E2.80.93_dummy|immune to poison]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 3 Opals, 1 Pearl, 2 Diamonds and 2 Emeralds</span><br/>
 <br/>
-=== Cursed Memories &ndash; staff ===
-<span style='color:#808080'><i>Every hero suffers from horrors of the past. Only a few can have their enemies suffer from them instead.</i></span><br/>
+=== Lightning Agility &ndash; craftable as any armour ===
+<span style='color:#808080'><i>That speed... Nothing can hit him.</i></span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 3 Topazes, 3 Opals and 1 Pearl</span><br/>
+<br/>
+=== Mastodon &ndash; craftable as any armour ===
+<span style='color:#808080'><i>You will need a lot of hits to strike down a mastodon.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:#60A0FF'>8 more hitpoints per level</span><br/>
+<span style='color:#60A0FF'>6 more hitpoints per level per level</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal and 3 Pearls</span><br/>
+<br/>
+=== Murderlust &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Killing makes you stronger, why should you stop doing it?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#penetrates_.E2.80.93_dummy|penetrates]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 3 Pearls, 1 Diamond, 1 Ruby and 2 Emeralds</span><br/>
+<br/>
+=== Nighwalker &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Black and transparent</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians and 1 Opal</span><br/>
+<br/>
+=== Perfection &ndash; craftable as any armour ===
+<span style='color:#808080'><i>I am from a perfect breed. Orcs are so low-born, they must be exterminated.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misorcia_.E2.80.93_damage|misorcia]]</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 20%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 1 Opal, 1 Diamond and 2 Rubies</span><br/>
+<br/>
+=== Prayer &ndash; craftable as any armour ===
+<span style='color:#808080'><i>'I feel sick, can you help me?'
+'No, but I shall pray for you.'</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<span style='color:#60A0FF'>New ability: cures</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Opal, 3 Pearls, 3 Diamonds and 2 Rubies</span><br/>
+<br/>
+=== Purity &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Glory of the pure led the nocturnal creatures away.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#improved illumination_.E2.80.93_illuminates|improved illumination]]</span><br/>
+<span style='color:#60A0FF'>Sets alignment to lawful</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 4 Topazes, 2 Diamonds and 1 Amethyst</span><br/>
+<br/>
+=== Quintessence &ndash; craftable as any armour ===
+<span style='color:#808080'><i>'All is made of four elements.'
+'Master, four is not a pretty number. Why not five?'
+'Very well, I was testing you. There is a fifth element.'</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<span style='color:purple'>New ability: regenerates (requires [[#The Essence of Magic_.E2.80.93_craftable as any weapon|The Essence of Magic]])</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 3 Opals, 1 Ruby, 2 Emeralds and 1 Amethyst</span><br/>
+<br/>
+=== Scourge of All Living &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Stories talk about a disease that comes out of nowhere and no one can survive.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 30%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#cancer_.E2.80.93_dummy|cancer]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 1 Opal, 1 Pearl, 1 Diamond and 1 Emerald</span><br/>
+<br/>
+=== Sorcery &ndash; craftable as any armour ===
+<span style='color:#808080'><i>'You shall never question my power!'
+'Only because of that cheap decorated armour of yours?'</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal and 2 Pearls</span><br/>
+<br/>
+=== Spell Devourer &ndash; craftable as any armour ===
+<span style='color:#808080'><i>When the mighty wizard saw soldiers wearing armour protecting from his magic, he summoned undead to fight them.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 3 Pearls, 3 Diamonds and 2 Rubies</span><br/>
+<br/>
+=== Spiritual Presence &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Run through hills, swamps and sand as if you had no body limiting you.</i></span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 40%</span><br/>
+<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on flat terrains set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through villages set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through castles set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on coastal reefs set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through swampy places set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs across sands set to 1</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Opal, 1 Diamond, 3 Emeralds, 2 Amethysts and 1 Sapphire</span><br/>
+<br/>
+=== Strength &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Why does nobody want to play handwrestling with me?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 3 Topazes and 2 Opals</span><br/>
+<br/>
+=== The Art of War &ndash; craftable as any armour ===
+<span style='color:#808080'><i>If you know the enemy and you know yourself, you need not fear the outcome of a thousand battles.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:green'>Damage increased by 3</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (25)]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 2 Topazes, 1 Opal, 1 Pearl, 3 Emeralds and 3 Sapphires</span><br/>
+<br/>
+=== The Godless &ndash; craftable as any armour ===
+<span style='color:#808080'><i>Do not justify your actions with the name of a man made deity.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 35%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 30%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Topaz, 1 Opal, 1 Pearl, 1 Diamond, 1 Ruby and 1 Emerald</span><br/>
+<br/>
+=== The Shiverbringer &ndash; craftable as any armour ===
+<span style='color:#808080'><i>His presence brought shivers of fear to everyone who defied him. He was defeated by the insane.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal, 2 Diamonds, 2 Rubies, 1 Emerald and 1 Amethyst</span><br/>
+<br/>
+=== Unimpalability &ndash; craftable as any armour ===
+<span style='color:#808080'><i>The executioner tried to impale him on a stick. It was his last mistake.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 40%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#frail tide (INTENSITY)_.E2.80.93_resistance|frail tide (15)]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Opals and 1 Pearl</span><br/>
+<br/>
+=== Warheart &ndash; craftable as any armour ===
+<span style='color:#808080'><i>This will please my war loving heart.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (10)]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal, 1 Diamond, 2 Rubies and 1 Amethyst</span><br/>
+<br/>
+== craftable as any weapon ==
+=== Anger &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>If we were not born to rage, why would we have the ability to rage then?</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal, 3 Rubies and 1 Emerald</span><br/>
+<br/>
+=== Dominion &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Obey.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 20% (in MEDIUM difficulty), 0% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#mind raid_.E2.80.93_dummy|mind raid]]</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 2 Opals, 1 Pearl, 2 Emeralds and 1 Amethyst</span><br/>
+<br/>
+=== Dugi's Wrath &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>The probability that somebody will get this is quite low, maybe some of my assumptions were wrong.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:#60A0FF'>Spells suck 2 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>15% chance to strike a devastating blow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
+<span style='color:green'>New weapon special: berserk</span><br/>
+<span style='color:green'>New weapon special: charge</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#radiating insanity_.E2.80.93_dummy|radiating insanity]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#warlord's rule_.E2.80.93_dummy|warlord's rule]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 3 Topazes, 3 Opals, 3 Pearls, 3 Diamonds, 10 Rubies, 10 Emeralds, 10 Amethysts, 10 Sapphires and 10 Black Pearls</span><br/>
+<br/>
+=== Equality &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Even the weak can kill with this one.</i></span><br/>
 <span style='color:green'>Damage increased by 7 (in EASY difficulty), 6 (in MEDIUM difficulty), 5 (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Topazes and 2 Opals</span><br/>
+<br/>
+=== Forestburner &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Sarah always preferred money over pristine nature.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misdryadia_.E2.80.93_damage|misdryadia]]</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
+<span style='color:green'>New attack: fireball (13 - 4, fire)</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal, 4 Rubies and 1 Amethyst</span><br/>
+<br/>
+=== Gloombringer &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>One side wins, the other side loses. Both sides' widows weep.</i></span><br/>
+<span style='color:green'>Damage increased by 80% (in EASY difficulty), 50% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 1 Ruby, 4 Emeralds and 1 Amethyst</span><br/>
+<br/>
+=== Guerrilla &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Fight when you choose to fight, hide when you are hunted.</i></span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#hit and run_.E2.80.93_dummy|hit and run]]</span><br/>
+<span style='color:#60A0FF'>New ability: concealment</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Topaz, 1 Opal, 1 Pearl, 1 Diamond, 2 Emeralds and 1 Sapphire</span><br/>
+<br/>
+=== Inferno &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Infernal flames will devour those who are struck with the ruby-clad weapon.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal, 3 Rubies and 2 Emeralds</span><br/>
+<br/>
+=== Konrad's Might &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>No sword or shield can protect from my wrath.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians and 1 Topaz</span><br/>
+<br/>
+=== Malice &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Dishonest combat is usually stronger.</i></span><br/>
+<span style='color:green'>Damage increased by 25%</span><br/>
+<span style='color:green'>Damage increased by 4</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: backstab</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Pearl and 1 Diamond</span><br/>
+<br/>
+=== Marie Byrd &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>He set foot into the Land of Always Winter and named it after his wife.</i></span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 55% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 40%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Pearl, 1 Diamond, 1 Emerald and 4 Sapphires</span><br/>
+<br/>
+=== Marrowrend &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Let your anger penetrate into the depths of your bones.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 25% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>Sets damage type to impact</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to impact decreased by 20%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Opal, 1 Pearl, 3 Rubies and 1 Black Pearl</span><br/>
+<br/>
+=== Misanthropia &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>I have seen pillagers torturing children for fun. The worst of monsters are humans. They must be smitten.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 20%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misanthropia_.E2.80.93_damage|misanthropia]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misnania_.E2.80.93_damage|misnania]]</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Pearl, 2 Diamonds and 1 Emerald</span><br/>
+<br/>
+=== Scaryface &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Behold my countenance and tremble!</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Damage increased by 3</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
 <span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
-<span style='color:green'>Increases all magical damages by 40% (in EASY difficulty), 35% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to fire decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 40%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal, 1 Amethyst and 1 Sapphire</span><br/>
+<br/>
+=== Soul Eclipse &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Hide your soul and gifts of undeath await you.</i></span><br/>
+<span style='color:green'>Damage increased by 4 (in EASY difficulty), 0 (in MEDIUM difficulty), -4 (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: drain</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Unlife (immunity to poison, plague and drain)</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 2 Topazes, 3 Diamonds, 1 Emerald and 2 Amethysts</span><br/>
+<br/>
+=== Soul Hunter &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Noble cannibals do not eat corpses, they eat souls.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 3 Opals and 2 Pearls</span><br/>
+<br/>
+=== Soul Render &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Sticks and stones will break his bones, but this will destroy even his soul.</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 55% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
+<span style='color:green'>Increases all magical damages by 30%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 1 Pearl, 2 Rubies, 3 Emeralds, 1 Amethyst, 2 Sapphires and 1 Black Pearl</span><br/>
+<br/>
+=== The End of All that Is &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>From the victim's point of view, there was no death at all.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#soul annihilation_.E2.80.93_damage|soul annihilation]]</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Opal, 1 Pearl, 3 Diamonds, 1 Ruby, 2 Emeralds and 1 Amethyst</span><br/>
+<br/>
+=== The Essence of Magic &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Fire, earth, air and water. And then there is magic.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:green'>Increases all magical damages by 35%</span><br/>
+<span style='color:purple'>5% to all resistances to magic (requires [[#Quintessence_.E2.80.93_craftable as any armour|Quintessence]])</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Pearl, 1 Diamond and 1 Ruby</span><br/>
+<br/>
+=== The Lesser Lich &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Let this skeleton be my lieutenant. They will not notice any difference.</i></span><br/>
+<span style='color:green'>30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:#60A0FF'>Sucks 2 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Soulless)]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 1 Topaz, 1 Pearl, 1 Emerald, 1 Amethyst, 2 Sapphires and 1 Black Pearl</span><br/>
+<br/>
+=== Thundering Revenge &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>I call this new weapon of mine.. bazooka!</i></span><br/>
+<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
+<span style='color:green'>Sets damage type to lightning</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#explosive_.E2.80.93_damage|explosive]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Pearl, 2 Rubies, 3 Emeralds and 1 Sapphire</span><br/>
+<br/>
+=== Widowmaker, Widowermaker &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>The number of widows will rise after this battle.</i></span><br/>
+<span style='color:green'>Damage decreased by 10%</span><br/>
+<span style='color:green'>New weapon special: charge</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Opal, 2 Pearls and 1 Diamond</span><br/>
+<br/>
+=== Wretched Defiler &ndash; craftable as any weapon ===
+<span style='color:#808080'><i>Minimise your casualties, even at the cost of defiling corpses.</i></span><br/>
+<span style='color:green'>Damage increased by 25%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Soulless)]]</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 25%</span><br/>
+<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 2 Opals and 1 Pearl</span><br/>
+<br/>
+== dagger ==
+=== Chaosbringer &ndash; dagger ===
+<span style='color:#808080'><i>Do you like order? Shame that I do not.</i></span><br/>
+<span style='color:green'>40% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misanthropia_.E2.80.93_damage|misanthropia]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misnania_.E2.80.93_damage|misnania]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#misdryadia_.E2.80.93_damage|misdryadia]]</span><br/>
 <br/>
 === Dagger of Craving &ndash; dagger ===
 <span style='color:#808080'><i>Does this make you feel some sort of... bloodlust?</i></span><br/>
@@ -543,149 +1623,86 @@ and saved the righteous.</i></span><br/>
 <span style='color:green'>New weapon special: backstab</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
 <br/>
+=== Exterminator's Dagger &ndash; dagger ===
+<span style='color:#808080'><i>Slay the tyrant. Put an end to his wicked rule.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
+<br/>
+=== Exterminator's Dagger &ndash; dagger ===
+<span style='color:#808080'><i>Slay the tyrant. Put an end to his wicked rule.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
+<br/>
+=== Nightstalker &ndash; dagger ===
+<span style='color:#808080'><i>That looming darkness is a herald of his arrival. Somebody will die very soon.</i></span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#greater backstab_.E2.80.93_damage|greater backstab]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens_.E2.80.93_illuminates|darkens]]</span><br/>
+<span style='color:#60A0FF'>New ability: nightstalk</span><br/>
+<br/>
+=== Souldrainer &ndash; dagger ===
+<span style='color:#808080'><i>To kill or to preserve oneself? One has to consider the situation.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Straight out of Nowhere &ndash; dagger ===
+<span style='color:#808080'><i>Expect the unexpected. Diabolus ex machina.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:green'>Merges attacks</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<br/>
+=== Survival of the Cowardliest &ndash; dagger ===
+<span style='color:#808080'><i>Revered men once went to war. Revered men now lay in red mud.</i></span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#greater backstab_.E2.80.93_damage|greater backstab]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#cowardice_.E2.80.93_dummy|cowardice]]</span><br/>
+<br/>
+=== The Psychotic's Dagger &ndash; dagger ===
+<span style='color:#808080'><i>I will kill you! Kill! Kill! Hahahahahahaha, aaahahahahahahaaa! Hahahaaa!</i></span><br/>
+<span style='color:green'>30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<br/>
+=== Titan's Bane &ndash; dagger ===
+<span style='color:#808080'><i>My blows may cause mere scratches on your skin, but it can be enough for you to die.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:#60A0FF'>20% chance to strike a devastating blow</span><br/>
+<br/>
+=== Traces of Blood &ndash; dagger ===
+<span style='color:#808080'><i>That assassin is hard to find, but his bloody trace can be followed. Shame that it costs so many lives.</i></span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 50% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
+<br/>
+== gauntlets ==
+=== Brawler's Triumph &ndash; gauntlets ===
+<span style='color:#808080'><i>It protects well... but not as much from punches.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<br/>
+=== Chilling Touch &ndash; gauntlets ===
+<span style='color:#808080'><i>Unnatural clouds of dust can come and cover the sun. No heat will come and summer crops will be touched by chill.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage decreased by 3</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<span style='color:purple'>New ability: freezing aura (requires [[#Heart of Ice_.E2.80.93_armour|Heart of Ice]])</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#Iced Boots_.E2.80.93_boots|Iced Boots]])</span><br/>
+<br/>
 === Dark Gloves of Destruction &ndash; gauntlets ===
 <span style='color:#808080'><i>Surviving warriors have learned that healing while fighting is necessary for survival.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
 <span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
 <span style='color:purple'>+1 base damage (requires [[#Dark Sword of Destruction_.E2.80.93_sword|Dark Sword of Destruction]])</span><br/>
 <span style='color:purple'>+1 base damage (requires [[#Dark Helm of Destruction_.E2.80.93_helm|Dark Helm of Destruction]])</span><br/>
-<br/>
-=== Dark Helm of Destruction &ndash; helm ===
-<span style='color:#808080'><i>Deadly warriors wear even offensive armour.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#Dark Sword of Destruction_.E2.80.93_sword|Dark Sword of Destruction]])</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#Dark Gloves of Destruction_.E2.80.93_gauntlets|Dark Gloves of Destruction]])</span><br/>
-<br/>
-=== Dark Sarcasm &ndash; armour ===
-<span style='color:#808080'><i>You missed! You cannot even hit me! Hahahaha! I feel so good to see you fail, loser!</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#mockery_.E2.80.93_dummy|mockery]]</span><br/>
-<br/>
-=== Dark Sword of Destruction &ndash; sword ===
-<span style='color:#808080'><i>Real warriors know that their opponents will get heavy armours and prepare for it.</i></span><br/>
-<span style='color:green'>Damage increased by 50%</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
-<span style='color:purple'>+1 to base attacks (requires [[#Dark Helm of Destruction_.E2.80.93_helm|Dark Helm of Destruction]])</span><br/>
-<span style='color:purple'>+1 to base attacks (requires [[#Dark Gloves of Destruction_.E2.80.93_gauntlets|Dark Gloves of Destruction]])</span><br/>
-<br/>
-=== Dazzling Ring &ndash; ring ===
-<span style='color:#808080'><i>You were born to die blind.</i></span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#dazzle_.E2.80.93_dummy|dazzle]]</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<br/>
-=== Dead End Road &ndash; staff ===
-<span style='color:#808080'><i>You will walk away from a necromancer fight. That does not imply that you will survive.</i></span><br/>
-<span style='color:green'>Damage increased by 25%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#greater infect_.E2.80.93_poison|greater infect]]</span><br/>
-<span style='color:green'>Increases all magical damages by 25%</span><br/>
-<br/>
-=== Deathblade Inheritance &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>It might not hit hard, but it will bring you reinforcements.</i></span><br/>
-<span style='color:green'>40% (in EASY difficulty), 35% (in MEDIUM difficulty), 30% (in HARD difficulty) more attacks</span><br/>
-<span style='color:green'>Sets damage type to blade</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Deathblade)]]</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 1 Topaz, 1 Pearl, 1 Emerald, 1 Amethyst, 2 Sapphires and 1 Black Pearl</span><br/>
-<br/>
-=== Deathwhirl &ndash; sword ===
-<span style='color:#808080'><i>Swarm him so that he would not get to me! Oh, dammit...</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#penetrates_.E2.80.93_dummy|penetrates]]</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Defender of the Faith &ndash; armour ===
-<span style='color:#808080'><i>We shall clear the world of this filth!</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 15%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Defensive Stance &ndash; craftable as any armour ===
-<span style='color:#808080'><i>A good defence is the best offence.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20% (in EASY difficulty), 15% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: steadfast</span><br/>
-<span style='color:#60A0FF'>2 fewer movement points</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians and 2 Topazes</span><br/>
-<br/>
-=== Deflector of Light &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Drive all light away and enjoy the darkness.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens severely_.E2.80.93_illuminates|darkens severely]]</span><br/>
-<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 4 Obsidians, 2 Topazes, 1 Opal, 3 Diamonds, 1 Ruby and 1 Emerald</span><br/>
-<br/>
-=== Demon Core &ndash; amulet ===
-<span style='color:#808080'><i>If you awaken it, foul light will ravage flesh.</i></span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#radiation_.E2.80.93_dummy|radiation]]</span><br/>
-<br/>
-=== Despicable Heroism &ndash; mace ===
-<span style='color:#808080'><i>Your deeds are revered, but the way you do them is damned.</i></span><br/>
-<span style='color:green'>Damage decreased by 40% (in EASY difficulty), 50% (in MEDIUM difficulty), 55% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Revenant)]]</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane decreased by 5%</span><br/>
-<br/>
-=== Diadem of the Dark Headmaster &ndash; helm ===
-<span style='color:#808080'><i>He presides. He protects. He teaches. He attacks.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<br/>
-=== Diamond &ndash; gem ===
-<span style='color:#808080'><i>This colourless precious stone is known to be the hardest mineral, but it is too fragile to be used in weapons or armour as a hard material. However, it very useful due to its magical properties</i></span><br/>
-<br/>
-=== Dominion &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Obey.</i></span><br/>
-<span style='color:green'>Damage increased by 40% (in EASY difficulty), 20% (in MEDIUM difficulty), 0% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#mind raid_.E2.80.93_dummy|mind raid]]</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 2 Opals, 1 Pearl, 2 Emeralds and 1 Amethyst</span><br/>
-<br/>
-=== Doombringer &ndash; sword ===
-<span style='color:#808080'><i>Hitting the enemy hard is not crucial. You have to make sure that you will not get killed when he hits you.</i></span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#disintegrate_.E2.80.93_damage|disintegrate]]</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<br/>
-=== Doomsday Machine &ndash; xbow ===
-<span style='color:#808080'><i>To spread doom, you need proper tools.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#shockwave_.E2.80.93_slow|shockwave]]</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<br/>
-=== Dragon Claw &ndash; sword ===
-<span style='color:#808080'><i>Claws of dragons have no unusual magical properties, but they cut so well.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<br/>
-=== Dragonslayer &ndash; bow ===
-<span style='color:#808080'><i>He killed dragons with his legendary bow, but he was no match for saurians.</i></span><br/>
-<span style='color:green'>Damage increased by 35%</span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misdraconia_.E2.80.93_damage|misdraconia]]</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
 <br/>
 === Draingloves &ndash; gauntlets ===
 <span style='color:#808080'><i>You hit, you heal. I hit, you heal. But can you heal enough?</i></span><br/>
@@ -694,82 +1711,6 @@ and saved the righteous.</i></span><br/>
 <span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
 <span style='color:green'>Increases all magical damages by 5%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
-<br/>
-=== Dugi's Ward &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Metal is the best, especially if it's heavy enough.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
-<span style='color:green'>Damage increased by 15%</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (3)_.E2.80.93_dummy|absorbs (3)]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 2 Topazes, 2 Opals, 2 Pearls, 2 Diamonds, 2 Rubies, 4 Emeralds, 4 Amethysts, 4 Sapphires and 4 Black Pearls</span><br/>
-<br/>
-=== Dugi's Wrath &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>The probability that somebody will get this is quite low, maybe some of my assumptions were wrong.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:#60A0FF'>Spells suck 2 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>15% chance to strike a devastating blow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
-<span style='color:green'>New weapon special: berserk</span><br/>
-<span style='color:green'>New weapon special: charge</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#radiating insanity_.E2.80.93_dummy|radiating insanity]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#warlord's rule_.E2.80.93_dummy|warlord's rule]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 3 Topazes, 3 Opals, 3 Pearls, 3 Diamonds, 10 Rubies, 10 Emeralds, 10 Amethysts, 10 Sapphires and 10 Black Pearls</span><br/>
-<br/>
-=== Dying Dreams &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Have you ever dreamed of defeating me? Feel your weakness and see me recovering from everything.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leeches_.E2.80.93_dummy|leech]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (15)]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 2 Topazes, 2 Diamonds, 3 Rubies and 1 Emerald</span><br/>
-<br/>
-=== Eidolon's Armour &ndash; armour ===
-<span style='color:#808080'><i>Clothes, masks and cosmetics helped him conceal his etherealness, his defeat of an undead army made him a nobleman.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
-<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
-<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
-<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
-<span style='color:purple'>1 to movement (requires [[#Eidolon's Boots_.E2.80.93_boots|Eidolon's Boots]])</span><br/>
-<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
-<span style='color:purple'>New ability: Wrath (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
-<br/>
-=== Eidolon's Boots &ndash; boots ===
-<span style='color:#808080'><i>His champion in shining armour faced evils for centuries, often together with his children. The land became prosperous.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
-<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
-<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
-<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
-<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
-<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
-<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
-<span style='color:purple'>New ability: Wardrums (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
-<br/>
-=== Eidolon's Coat &ndash; cloak ===
-<span style='color:#808080'><i>He, a being of darkness, studied the art of white mages for generations. He learned the powers of light.</i></span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:#60A0FF'>New ability: cures</span><br/>
-<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
-<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
-<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
-<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
-<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
-<span style='color:purple'>New ability: Absorbs (1) (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
 <br/>
 === Eidolon's Gauntlets &ndash; gauntlets ===
 <span style='color:#808080'><i>He hired white mages to imbue a glorious warrior with their power. The warrior thought this power came from a god.</i></span><br/>
@@ -784,6 +1725,178 @@ and saved the righteous.</i></span><br/>
 <span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
 <span style='color:purple'>New ability: Steals (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
 <br/>
+=== Fiery Blood &ndash; gauntlets ===
+<span style='color:#808080'><i>Red is the fire. Red is the blood. I am not sure which of them is pouring.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<br/>
+=== Grim Trigger &ndash; gauntlets ===
+<span style='color:#808080'><i>If someone throws stones at you, make an example out of him and no one will ever dare again.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#triggerable_.E2.80.93_dummy|triggerable]]</span><br/>
+<br/>
+=== Hands of Sorrow &ndash; gauntlets ===
+<span style='color:#808080'><i>He grew up as a mercenary bound to obey any command. Remorse led him to distant corners where he died, miserable and alone.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
+<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
+<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (5)]]</span><br/>
+<br/>
+=== Heavy Gauntlets &ndash; gauntlets ===
+<span style='color:#808080'><i>How the hell do you fight with this?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<br/>
+=== Heavy Gauntlets of Virility &ndash; gauntlets ===
+<span style='color:#808080'><i>It protects you well, but are you sure that you can lift a weapon with that?</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>4 more hitpoints per level per level</span><br/>
+<br/>
+=== Hellslash &ndash; gauntlets ===
+<span style='color:#808080'><i>Careful about him, you will get hurt even if he is not attacking you.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#cleave_.E2.80.93_damage|cleave]] (melee attacks only)</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
+<br/>
+=== Mighty Gauntlets &ndash; gauntlets ===
+<span style='color:#808080'><i>Like any other visitor, he put his sword on a rack outside. His mighty fists were deadly enough.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<br/>
+=== Quick Gauntlets &ndash; gauntlets ===
+<span style='color:#808080'><i>Quick hands are the best defence.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:green'>Increases all magical damages by 5%</span><br/>
+<br/>
+=== Rationality &ndash; gauntlets ===
+<span style='color:#808080'><i>Magic is just very well made quackery.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Sets damage type to blade</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
+<br/>
+=== Soul Thrash &ndash; gauntlets ===
+<span style='color:#808080'><i>'My life is in ruins, if I die, I cannot lose anything.'
+Then he saw this item.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#soul thrash_.E2.80.93_damage|soul thrash]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<br/>
+=== Stormgrip &ndash; gauntlets ===
+<span style='color:#808080'><i>You are an evil overlord, armoured and shielded against everything? I will slay you anyway.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Sets damage type to lightning</span><br/>
+<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
+<br/>
+=== The Touch of Death &ndash; gauntlets ===
+<span style='color:#808080'><i>There is no touch of death. But you can take your time to aim at the windpipe from the correct angle...</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Damage increased by 20 (in EASY difficulty), 18 (in MEDIUM difficulty), 16 (in HARD difficulty)</span><br/>
+<span style='color:green'>4 fewer attacks</span><br/>
+<br/>
+=== Unspoken Words &ndash; gauntlets ===
+<span style='color:#808080'><i>No matter how wise you are, your words once shall be forgotten. But meaning may remain.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 5%</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 5%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:purple'>4% to all physical resistances (requires [[#Unseen Writings_.E2.80.93_cloak|Unseen Writings]])</span><br/>
+<span style='color:purple'>4% to magical resistances (requires [[#Unthought Memories_.E2.80.93_amulet|Unthought Memories]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Unsung Odes_.E2.80.93_armour|Unsung Odes]])</span><br/>
+<br/>
+== gem ==
+=== Amethyst &ndash; gem ===
+<span style='color:#808080'><i>These purple precious stones always attracted people for their massive magical power. However, its use as decoration by those without any knowledge of magic is widespread.</i></span><br/>
+<br/>
+=== Black Pearl &ndash; gem ===
+<span style='color:#808080'><i>Black pearls are legendarily rare and powerful items, investigated because of its powers reaching beyond the borders of standard magic.</i></span><br/>
+<br/>
+=== Diamond &ndash; gem ===
+<span style='color:#808080'><i>This colourless precious stone is known to be the hardest mineral, but it is too fragile to be used in weapons or armour as a hard material. However, it very useful due to its magical properties.</i></span><br/>
+<br/>
+=== Emerald &ndash; gem ===
+<span style='color:#808080'><i>Diamonds tainted with copper salts are coloured green and possess huge magical power. However, it is uneasy to extract it.</i></span><br/>
+<br/>
+=== Obsidian &ndash; gem ===
+<span style='color:#808080'><i>Although this gem looks interesting in appearance, its magical power is limited. However, in combination with other gems, it can find some use.</i></span><br/>
+<br/>
+=== Opal &ndash; gem ===
+<span style='color:#808080'><i>This is the least rare of precious gems, but it can be still used to craft useful items.</i></span><br/>
+<br/>
+=== Pearl &ndash; gem ===
+<span style='color:#808080'><i>This is one of the few kinds of precious gems that are grown, and not created by volcanic or tectonic processes. It has a wide use in decorating things or granting them magical properties.</i></span><br/>
+<br/>
+=== Ruby &ndash; gem ===
+<span style='color:#808080'><i>This is a diamond containing other minerals, that make its colour bright red. Its magical power is strong, and it can be used to create powerful magical things.</i></span><br/>
+<br/>
+=== Sapphire &ndash; gem ===
+<span style='color:#808080'><i>This incredibly rare colour variation is highly sought after for its incredible magical power.</i></span><br/>
+<br/>
+=== Topaz &ndash; gem ===
+<span style='color:#808080'><i>Although this gem looks interesting in appearance, its magical power is not really remarkable, but its importance for magical gem combination is not to be neglected.</i></span><br/>
+<br/>
+== gold ==
+=== 100 gold &ndash; gold ===
+<span style='color:#808080'><i>Why conquer when you can buy?</i></span><br/>
+<span style='color:#808080'><i>100 gold</i></span><br/>
+<br/>
+=== 200 gold &ndash; gold ===
+<span style='color:#808080'><i>Money will not buy you anything. It is you who has to buy it for money.</i></span><br/>
+<span style='color:#808080'><i>200 gold</i></span><br/>
+<br/>
+=== 50 gold &ndash; gold ===
+<span style='color:#808080'><i>Money is more powerful than magic.</i></span><br/>
+<span style='color:#808080'><i>50 gold</i></span><br/>
+<br/>
+== helm ==
+=== Apricity &ndash; helm ===
+<span style='color:#808080'><i>In winter, the burning sun is actually enjoyable.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Crown of the King &ndash; helm ===
+<span style='color:#808080'><i>The masses obeyed the one who had the crown. Whoever it was.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:purple'>New Ability: cantor (requires [[#Ring of the King_.E2.80.93_ring|Ring of the King]])</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Armour of the King_.E2.80.93_armour|Armour of the King]])</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#Sceptre of the King_.E2.80.93_mace|Sceptre of the King]])</span><br/>
+<br/>
+=== Cunctator's Helmet &ndash; helm ===
+<span style='color:#808080'><i>If you command Cunctator to attack immediately, he will not obey.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
+<span style='color:green'>Damage decreased by 10% (in EASY difficulty), 20% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (15)]]</span><br/>
+<span style='color:purple'>New ability: careful (10) (requires [[#Cunctator's sword_.E2.80.93_sword|Cunctator's Sword]])</span><br/>
+<span style='color:purple'>New ability: 10% to physical resistances (requires [[#Cunctator's Armour_.E2.80.93_armour|Cunctator's Armour]])</span><br/>
+<br/>
+=== Dark Helm of Destruction &ndash; helm ===
+<span style='color:#808080'><i>Deadly warriors wear even offensive armour.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#Dark Sword of Destruction_.E2.80.93_sword|Dark Sword of Destruction]])</span><br/>
+<span style='color:purple'>+1 base damage (requires [[#Dark Gloves of Destruction_.E2.80.93_gauntlets|Dark Gloves of Destruction]])</span><br/>
+<br/>
+=== Diadem of the Dark Headmaster &ndash; helm ===
+<span style='color:#808080'><i>He presides. He protects. He teaches. He attacks.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<br/>
 === Eidolon's Mask &ndash; helm ===
 <span style='color:#808080'><i>His experience showed him that if dead are all around, people need a champion. Otherwise they fall without resistance.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
@@ -795,505 +1908,16 @@ and saved the righteous.</i></span><br/>
 <span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
 <span style='color:purple'>New ability: Mockery (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
 <br/>
-=== Eidolon's Necklace &ndash; amulet ===
-<span style='color:#808080'><i>He was ingenious enough to become something new, not a pack of bones but a spirit. An opaque one.</i></span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
-<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
-<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
-<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
-<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
-<span style='color:purple'>1 to movement (requires [[#Eidolon's Boots_.E2.80.93_boots|Eidolon's Boots]])</span><br/>
-<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
-<span style='color:purple'>New ability: Frail Tide (15) (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
-<br/>
-=== Eidolon's Ring &ndash; ring ===
-<span style='color:#808080'><i>When he was old and dying, he remembered what he could from the days he loved a necromanceress.</i></span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
-<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
-<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
-<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
-<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
-<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
-<span style='color:purple'>New ability: Deathaura (8) (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
-<br/>
-=== Eidolon's Sword &ndash; sword ===
-<span style='color:#808080'><i>He could fuel his champion alone, as his powers of light and darkness amplified each other. He became an Eidolon.</i></span><br/>
-<span style='color:green'>Sets damage type to arcane</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#unholybane_.E2.80.93_damage|unholybane]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
-<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
-<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
-<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
-<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
-<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
-<span style='color:purple'>1 to movement (requires [[#Eidolon's Boots_.E2.80.93_boots|Eidolon's Boots]])</span><br/>
-<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
-<br/>
-=== Elusive Boots &ndash; boots ===
-<span style='color:#808080'><i>Enemies are blocking the way? Who cares?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 2%</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
-<br/>
-=== Emerald &ndash; gem ===
-<span style='color:#808080'><i>Diamonds tainted with copper salts are coloured green and possess huge magical power. However, it is uneasy to extract it.</i></span><br/>
-<br/>
-=== Equality &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Even the weak can kill with this one.</i></span><br/>
-<span style='color:green'>Damage increased by 7 (in EASY difficulty), 6 (in MEDIUM difficulty), 5 (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Topazes and 2 Opals</span><br/>
-<br/>
-=== Executioner's Axe &ndash; axe ===
-<span style='color:#808080'><i>A good executioner kills with a single blow.</i></span><br/>
-<span style='color:green'>Merges attacks</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
-<span style='color:#60A0FF'>Sets alignment to neutral</span><br/>
-<br/>
-=== Explosionlance &ndash; spear ===
-<span style='color:#808080'><i>Take that away, we need to stay silent.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#extra damage (+5; impact)_.E2.80.93_dummy|extra damage (+5; impact)]]</span><br/>
-<br/>
-=== Exterminator's Dagger &ndash; dagger ===
-<span style='color:#808080'><i>Slay the tyrant. Put an end to his wicked rule.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
-<br/>
-=== Exterminator's Knives &ndash; knife ===
-<span style='color:#808080'><i>It may be hard to get close enough.</i></span><br/>
-<span style='color:green'>Damage increased by 40%</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
-<span style='color:purple'>16 more hitpoints (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
-<span style='color:purple'>+1 to base attacks (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
-<br/>
-=== Exterminator's Ring &ndash; ring ===
-<span style='color:#808080'><i>Hide from the revolution.</i></span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
-<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
-<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
-<br/>
-=== Exterminator's Scythe &ndash; polearm ===
-<span style='color:#808080'><i>Victims' loyals look for revenge.</i></span><br/>
-<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<span style='color:green'>35% more attacks</span><br/>
-<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
-<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
-<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
-<br/>
 === False Paradise &ndash; helm ===
 <span style='color:#808080'><i>Their society was almost utopian. They grew lazy and weak and became an easy prey for invaders.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#regenerates (VALUE)_.E2.80.93_regenerate|regenerates (24)]]</span><br/>
 <span style='color:#60A0FF'>3 (in EASY difficulty), 4 (in MEDIUM difficulty), 5 (in HARD difficulty) fewer movement points</span><br/>
 <br/>
-=== Fiery Blood &ndash; gauntlets ===
-<span style='color:#808080'><i>Red is the fire. Red is the blood. I am not sure which of them is pouring.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<br/>
-=== Fine bow &ndash; bow ===
-<span style='color:#808080'><i>Precision is more important than anything else.</i></span><br/>
-<span style='color:green'>Damage increased by 40%</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<br/>
-=== Fire-Forged Friend &ndash; potion ===
-<span style='color:#808080'><i>'I make my friends with hammer and anvil.' -Pygmaliophaestus</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 50%</span><br/>
-<span style='color:#60A0FF'>4 fewer movement points</span><br/>
-<br/>
-=== Fist of Anarchy &ndash; mace ===
-<span style='color:#808080'><i>Rebirth through devastation, freedom through bloodshed.</i></span><br/>
-<span style='color:green'>60% (in EASY difficulty), 50% (in MEDIUM difficulty), 40% (in HARD difficulty) more attacks</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#anarchy_.E2.80.93_damage|anarchy]]</span><br/>
-<br/>
-=== Flaming Sword &ndash; sword ===
-<span style='color:#808080'><i>If you need to fight ghosts, good steel is not enough.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<br/>
-=== Fleshrending Scourge &ndash; mace ===
-<span style='color:#808080'><i>Do not run away from me. I will catch you anyway.</i></span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 40% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to impact decreased by 10%</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<br/>
-=== Flying Boots &ndash; boots ===
-<span style='color:#808080'><i>He could run through caves and hills like on a plain road. He could even walk on water.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 7%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on flat terrains set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through villages set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through castles set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs in shallow waters set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on coastal reefs set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs in deep waters set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through swampy places set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs across sands set to 1</span><br/>
-<br/>
-=== Forestburner &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Sarah always preferred money over pristine nature.</i></span><br/>
-<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misdryadia_.E2.80.93_damage|misdryadia]]</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
-<span style='color:green'>New attack: fireball (11 - 4, fire)</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal, 4 Rubies and 1 Amethyst</span><br/>
-<br/>
-=== Foul Potion &ndash; potion ===
-<span style='color:#808080'><i>It helps us greatly, but its user pays a great price.</i></span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unholy hunger_.E2.80.93_dummy|unholy hunger]]</span><br/>
-<br/>
-=== Fowleri's Chopper &ndash; axe ===
-<span style='color:#808080'><i>He broke her heart. No, wait, not heart, sanity. He broke her sanity.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 15% (in EASY difficulty), 5% (in MEDIUM difficulty), -5% (in HARD difficulty)</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Frozen Locket &ndash; amulet ===
-<span style='color:#808080'><i>Frozen memories shall thaw and redeem.</i></span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#freezing aura_.E2.80.93_dummy|freezing aura]]</span><br/>
-<br/>
-=== Glitch Item &ndash; limited ===
-<span style='color:#808080'><i>Everything can fail. Regardless of the amount of polishing done.</i></span><br/>
-<span style='color:red'>New obligation: Report this bug on the forums</span><br/>
-<br/>
-=== Gloombringer &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>One side wins, the other side loses. Both sides' widows weep.</i></span><br/>
-<span style='color:green'>Damage increased by 80% (in EASY difficulty), 50% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 1 Ruby, 4 Emeralds and 1 Amethyst</span><br/>
-<br/>
-=== Glowing Flight &ndash; knife ===
-<span style='color:#808080'><i>The pragmatic baron sent an assassin to kill a necromancer. It was not a bad idea.</i></span><br/>
-<span style='color:green'>Damage increased by 40%</span><br/>
-<span style='color:green'>40% more attacks</span><br/>
-<span style='color:green'>Sets damage type to arcane</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<br/>
-=== Godsmasher &ndash; mace ===
-<span style='color:#808080'><i>'With this beast, I can kill even a god!'
-'Crunch, munch,... burp. Anybody else thinks that it can kill dragons too?'</i></span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:green'>Enemy resistances to impact decreased by 20%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
-<br/>
-=== Greater Guardsman's Leather Armour &ndash; armour ===
-<span style='color:#808080'><i>A good guardsman never yields.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unyielding_.E2.80.93_resistance|unyielding]]</span><br/>
-<br/>
-=== Greater Healing Potion &ndash; potion ===
-<span style='color:#808080'><i>This can heal almost anyone, find the one who brewed it!</i></span><br/>
-<span style='color:orange'>This unit is completely restored, including statuses, moves and attacks.</span><br/>
-<br/>
-=== Guardsman's Leather Armour &ndash; armour ===
-<span style='color:#808080'><i>Loyalty will protect you like an expensive armour.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: steadfast</span><br/>
-<br/>
-=== Guerrilla &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Fight when you choose to fight, hide when you are hunted.</i></span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#hit and run_.E2.80.93_dummy|hit and run]]</span><br/>
-<span style='color:#60A0FF'>New ability: concealment</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Topaz, 1 Opal, 1 Pearl, 1 Diamond, 2 Emeralds and 1 Sapphire</span><br/>
-<br/>
-=== Guide to Lycanthropy &ndash; limited ===
-<span style='color:#808080'><i>Search your memories and find the monster you are.</i></span><br/>
-<span style='color:orange'>New advancements: Abilities that allow a transformation into powerful animal forms</span><br/>
-<br/>
-=== Gvødgührvoḧzzorghkuz &ndash; mace ===
-<span style='color:#808080'><i>Ürhrabgzubruprÿÿrv øẗhnäæzdaz grohruth züürd myyvöthgavrhyd...</i></span><br/>
-<span style='color:green'>30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
-<br/>
-=== Hands of Sorrow &ndash; gauntlets ===
-<span style='color:#808080'><i>He grew up as a mercenary bound to obey any command. Remorse led him to distant corners where he died, miserable and alone.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
-<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (5)]]</span><br/>
-<br/>
-=== Hatred &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Arm yourself with hatred, your lacking skill will not matter.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage increased by 7 (in EASY difficulty), 6 (in MEDIUM difficulty), 5 (in HARD difficulty)</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 2 Topazes, 1 Opal, 1 Amethyst, 2 Sapphires and 1 Black Pearl</span><br/>
-<br/>
-=== Hatred for Men &ndash; xbow ===
-<span style='color:#808080'><i>Fuelled by the venom and hatred.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#pierce_.E2.80.93_dummy|pierce]]</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (10)]]</span><br/>
-<br/>
-=== Havoc Bliss &ndash; amulet ===
-<span style='color:#808080'><i>Destruction can save you from suffering if you do it right.</i></span><br/>
-<span style='color:green'>Damage increased by 15%</span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Headsmasher &ndash; axe ===
-<span style='color:#808080'><i>'Let us give the orcs something they like, maybe they will let us be.'
-'What do they like?'
-'Smashing heads.'</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>60% more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<br/>
-=== Headstriker &ndash; xbow ===
-<span style='color:#808080'><i>If you have a good aim, you will hit a vulnerable spot and kill even with a lightweight bolt.</i></span><br/>
-<span style='color:green'>Damage increased by 25%</span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:green'>New weapon special: marksman</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
-<br/>
-=== Healing Potion &ndash; potion ===
-<span style='color:#808080'><i>I am healed! More healthy than ever!</i></span><br/>
-<span style='color:#60A0FF'>10 more hitpoints per level</span><br/>
-<span style='color=#60A0FF'>Full heal</span><br/>
-<br/>
-=== Heart of Darkness &ndash; limited ===
-<span style='color:#808080'><i>Find your dark subconscience and embrace it.</i></span><br/>
-<span style='color:orange'>New advancements: Various wicked spells</span><br/>
-<br/>
-=== Heart of Ice &ndash; armour ===
-<span style='color:#808080'><i>Even warm smokes can bring frost. The sun is what we need.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>New weapon special: slow (ranged attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to fire decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
-<span style='color:purple'>New weapon special: slows (melee attacks only) (requires [[#Iced Boots_.E2.80.93_boots|Iced Boots]])</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#Chilling Touch_.E2.80.93_gauntlets|Chilling Touch]])</span><br/>
-<br/>
-=== Heathenbasher &ndash; mace ===
-<span style='color:#808080'><i>Dark is the night that has set to your mind, sweet is the pride that reflects in your eyes.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#lawful_.E2.80.93_damage|lawful]]</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: illuminates</span><br/>
-<br/>
-=== Heavy Bow &ndash; bow ===
-<span style='color:#808080'><i>Fellows, what would you say if I made a bow that shoots spears?</i></span><br/>
-<span style='color:green'>Damage increased by 120% (in EASY difficulty), 100% (in MEDIUM difficulty), 80% (in HARD difficulty)</span><br/>
-<span style='color:green'>30% fewer attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#pierce_.E2.80.93_dummy|pierce]]</span><br/>
-<br/>
-=== Heavy Gauntlets &ndash; gauntlets ===
-<span style='color:#808080'><i>How the hell do you fight with this?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage decreased by 2 (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<br/>
-=== Heavy Gauntlets of Virility &ndash; gauntlets ===
-<span style='color:#808080'><i>It protects you well, but are you sure that you can lift a weapon with that?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage decreased by 2 (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>4 more hitpoints per level per level</span><br/>
-<br/>
-=== Hell Warlord's Armour &ndash; armour ===
-<span style='color:#808080'><i>Abaddon ruled Inferno with an iron hand, but it did not stop his loyals from following him.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:green'>Increases all magical damages by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 40%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#warlord's rule_.E2.80.93_dummy|warlord's rule]]</span><br/>
-<br/>
-=== Hellforge Armour &ndash; armour ===
-<span style='color:#808080'><i>'Forge me an armour. I need to have forged armour to stop attacks armour stops.' - Abaddon</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 35%</span><br/>
-<br/>
-=== Hellforge Armour of Forging &ndash; armour ===
-<span style='color:#808080'><i>Forge weapons. Give the forgery to your enemies. They shall see that forged arsenal is not useful.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 35%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
-<br/>
-=== Hellrake &ndash; spear ===
-<span style='color:#808080'><i>Flowers bloom in hell too. And every flower has its gardener.</i></span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 50% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Hellslash &ndash; gauntlets ===
-<span style='color:#808080'><i>Careful about him, you will get hurt even if he is not attacking you.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#cleave_.E2.80.93_damage|cleave]] (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
-<br/>
 === Helmet of Paladins &ndash; helm ===
 <span style='color:#808080'><i>Let the light show you the way into the darkness that you can enlighten.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
 <span style='color:#60A0FF'>New ability: illuminates</span><br/>
-<br/>
-=== Herod's Mithral Armour &ndash; armour ===
-<span style='color:#808080'><i>He was a poweful ruler, but he was not very righteous. No wonder that his cousin dethroned him.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (10)]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#steals_.E2.80.93_dummy|steals]]</span><br/>
-<br/>
-=== Holy potion &ndash; potion ===
-<span style='color:#808080'><i>Grrrh! Remove this filth from this world! Rrrargh!</i></span><br/>
-<span style='color:green'>New weapon special (melee attacks only): [[LotI_Abilities#unholybane_.E2.80.93_damage|unholybane]]</span><br/>
-<br/>
-=== Holy Sword &ndash; sword ===
-<span style='color:#808080'><i>You, comrade with that Unholy Axe, position yourself as far from me as possible!</i></span><br/>
-<span style='color:green'>Damage increased by 25%</span><br/>
-<span style='color:green'>Sets damage type to arcane</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: illuminates</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unholybane (INTENSITY)_.E2.80.93_heals|unholybane (12)]]</span><br/>
-<span style='color:#60A0FF'>Sets alignment to lawful</span><br/>
-<br/>
-=== Hope of the Fallen &ndash; armour ===
-<span style='color:#808080'><i>Dark immortality is encased in great sadness, but the encasement has its flaws.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce decreased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold decreased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 35%</span><br/>
-<br/>
-=== Horrid Ice Armour &ndash; armour ===
-<span style='color:#808080'><i>Frost not only causes you cold feet, it also kills a peasant's crops, veggies and culinary weed.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
-<br/>
-=== How to be an Overlord &ndash; limited ===
-<span style='color:#808080'><i>Attack! Attack! Attack!</i></span><br/>
-<span style='color:orange'>New advancements: Leadership-like abilities</span><br/>
-<br/>
-=== Hunter of Kings &ndash; armour ===
-<span style='color:#808080'><i>Nobody knows who he was. Nobody knows where he came from. Nobody knows how to stop him.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 25%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#frail tide (INTENSITY)_.E2.80.93_resistance|frail tide (30)]]</span><br/>
-<span style='color:purple'>New ability: conviction (20) (requires [[#Legion Slayer_.E2.80.93_cloak|Legion Slayer]])</span><br/>
-<br/>
-=== Ice Armour &ndash; armour ===
-<span style='color:#808080'><i>Dwarvish runes can prevent ice from melting.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
-<br/>
-=== Ice Armour of Health &ndash; armour ===
-<span style='color:#808080'><i>Hot weather is bad for health.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
-<span style='color:#60A0FF'>5 more hitpoints per level per level</span><br/>
-<br/>
-=== Iced Boots &ndash; boots ===
-<span style='color:#808080'><i>When flames fall from the skies or spring from the ground, hot days are not what you should fear.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:purple'>Movement increased by 1 (requires [[#Heart of Ice_.E2.80.93_armour|Heart of Ice]])</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#Chilling Touch_.E2.80.93_gauntlets|Chilling Touch]])</span><br/>
-<br/>
-=== Inferno &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Infernal flames will devour those who are struck with the ruby-clad weapon.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal, 3 Rubies and 2 Emeralds</span><br/>
-<br/>
-=== Intoxicator &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Orcish legends talk about a poison so potent that it debilitates its victims instantly.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 3%</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to poison_.E2.80.93_dummy|immune to poison]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 3 Opals, 1 Pearl, 2 Diamonds and 2 Emeralds</span><br/>
-<br/>
-=== Iridium &ndash; axe ===
-<span style='color:#808080'><i>Mages hypothetise that there is an extremely heavy metal that its ore's weight pulls it into depths.</i></span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 40% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>Damage increased by 4</span><br/>
-<br/>
-=== Iron Armour &ndash; armour ===
-<span style='color:#808080'><i>When choosing between a hundred warriors clad in iron and fifty warriors clad in mithril, choose iron.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 13		# You can tell to yourself that WTH this defence=13 cannot work, but there are other parts of the code that enable this%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== Iron Armour of the Friendly General &ndash; armour ===
-<span style='color:#808080'><i>I will not let you die, my protégé.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#shield (INTENSITY)_.E2.80.93_resistance|shield (20)]]</span><br/>
-<br/>
-=== Iron Armour of Thorns &ndash; armour ===
-<span style='color:#808080'><i>Do you think that you can attack me and leave uninjured?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#thorns_.E2.80.93_dummy|thorns]]</span><br/>
-<br/>
-=== Iron Sentinel &ndash; armour ===
-<span style='color:#808080'><i>If the defender cannot stop the attacks, he has to kill the enemies before they hurt him.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:green'>Enemy resistances to pierce decreased by 20%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
 <br/>
 === Irongut Helmet &ndash; helm ===
 <span style='color:#808080'><i>'Are those berries edible?'
@@ -1303,164 +1927,17 @@ and saved the righteous.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to poison_.E2.80.93_dummy|immune to poison]]</span><br/>
 <br/>
-=== Jawbreaker &ndash; mace ===
-<span style='color:#808080'><i>Why are you grinning like that? It could have killed you!</i></span><br/>
-<span style='color:green'>Damage decreased by 10% (in EASY difficulty), 20% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
-<br/>
 === King Salmon's Crown &ndash; helm ===
 <span style='color:#808080'><i>What? The king has a known name? Now I can no longer call him what I want...</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Konrad's Might &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>No sword or shield can protect from my wrath.</i></span><br/>
-<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:green'>New weapon special: marksman</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians and 1 Topaz</span><br/>
-<br/>
-=== Koschei's Journal &ndash; limited ===
-<span style='color:#808080'><i>The princess asked him where his soul was hidden. The prince found it.</i></span><br/>
-<span style='color:orange'>New advancements: Powerful improvements to spells</span><br/>
-<br/>
-=== Lake of Blood &ndash; axe ===
-<span style='color:#808080'><i>Liquids soak into the ground. To fill a lake, you have to gather liquids fast.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
-<span style='color:#60A0FF'>3 more movement points</span><br/>
-<br/>
-=== Leather Armour &ndash; armour ===
-<span style='color:#808080'><i>I know that it is cheap, but it does not slow me down.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<br/>
-=== Leechward &ndash; amulet ===
-<span style='color:#808080'><i>Transform your blood to acid and nobody will drink it.</i></span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to drain_.E2.80.93_dummy|immune to drain]]</span><br/>
-<br/>
-=== Legion Slayer &ndash; cloak ===
-<span style='color:#808080'><i>Nobody knows how he works. Nobody knows when he strikes. Nobody lives to tell how he looks.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#penetrates_.E2.80.93_dummy|penetrates]]</span><br/>
-<span style='color:purple'> 2 more movement points (requires [[#Hunter of Kings_.E2.80.93_armour|Hunter of Kings]])</span><br/>
-<br/>
-=== Lesser Potion of Invisibility &ndash; potion ===
-<span style='color:#808080'><i>When you are defeated, search for solace in the darkness.</i></span><br/>
-<span style='color:#60A0FF'>New ability: nightstalk</span><br/>
-<br/>
-=== Lethal Axe &ndash; axe ===
-<span style='color:#808080'><i>Girls went chopping for revenge. One of them prepared herself quite well.</i></span><br/>
-<span style='color:green'>Damage increased by 45%</span><br/>
-<span style='color:green'>35% more attacks</span><br/>
-<span style='color:green'>New weapon special: marksman</span><br/>
-<span style='color:purple'>10% more overall damage (requires [[#Lethal staff_.E2.80.93_staff|Lethal Staff]])</span><br/>
-<br/>
-=== Lethal staff &ndash; staff ===
-<span style='color:#808080'><i>Most elvish shamans heal. Others kill.</i></span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 15%</span><br/>
-<span style='color:green'>Increases all magical damages by 30%</span><br/>
-<span style='color:purple'>10% more overall damage (requires [[#Lethal Axe_.E2.80.93_axe|Lethal Axe]])</span><br/>
-<br/>
-=== Lethalia's Armour &ndash; armour ===
-<span style='color:#808080'><i>Tinebrithiel's legacy survives forever.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:purple'>5% to all base resistances (requires [[#Lethalia's Staff_.E2.80.93_staff|Lethalia's Staff]])</span><br/>
-<br/>
-=== Lethalia's Staff &ndash; staff ===
-<span style='color:#808080'><i>Tinebrithiel's legacy will never be forgotten.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:green'>Increases all magical damages by 30%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#Lethalia's Armour_.E2.80.93_armour|Lethalia's Armour]])</span><br/>
-<br/>
-=== Lightbringer's Trident &ndash; spear ===
-<span style='color:#808080'><i>He brought light, but it was red and searing.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>50% more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
-<br/>
-=== Lightning Agility &ndash; craftable as any armour ===
-<span style='color:#808080'><i>That speed... Nothing can hit him.</i></span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 3 Topazes, 3 Opals and 1 Pearl</span><br/>
-<br/>
-=== Lilith's Precious &ndash; axe ===
-<span style='color:#808080'><i>In order to be able to fight with any weapon available, Lilith swaps weapon types once per century.</i></span><br/>
-<span style='color:green'>Damage increased by 15% (in EASY difficulty), 5% (in MEDIUM difficulty), -5% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: charge</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<br/>
-=== Lionheart &ndash; armour ===
-<span style='color:#808080'><i>Lions spend twenty hours per day slacking. Yet they are a symbol of bravery. Like our nobles.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
-<br/>
-=== Liquid Hatred &ndash; amulet ===
-<span style='color:#808080'><i>The essence of liquid hatred, purified and distilled.</i></span><br/>
-<span style='color:green'>Damage decreased by 3</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
-<br/>
-=== Lucky Farmer's Amulet &ndash; amulet ===
-<span style='color:#808080'><i>Look at this trinket I found in my haystack. It will protect me from the atrocities of war.</i></span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
-<br/>
-=== Malice &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Dishonest combat is usually stronger.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: backstab</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Pearl and 1 Diamond</span><br/>
 <br/>
 === Man with a Vision &ndash; helm ===
 <span style='color:#808080'><i>His vision has the potential to bring sorrow and eternal tears to some</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
 <span style='color:green'>Damage increased by 10%</span><br/>
-<br/>
-=== Marie Byrd &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>He set foot into the Land of Always Winter and named it after his wife.</i></span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 55% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 40%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Pearl, 1 Diamond, 1 Emerald and 4 Sapphires</span><br/>
-<br/>
-=== Marilyn's Armour &ndash; armour ===
-<span style='color:#808080'><i>A manly man can have a woman's name without being funny.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:#60A0FF'>24 more hitpoints per level</span><br/>
-<br/>
-=== Marrowrend &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Let your anger penetrate into the depths of your bones.</i></span><br/>
-<span style='color:green'>Damage increased by 40% (in EASY difficulty), 25% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:green'>Sets damage type to impact</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to impact decreased by 20%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Opal, 1 Pearl, 3 Rubies and 1 Black Pearl</span><br/>
 <br/>
 === Mask of Famine &ndash; helm ===
 <span style='color:#808080'><i>His hunger... it feeds on everyone nearby!</i></span><br/>
@@ -1476,12 +1953,11 @@ and saved the righteous.</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit decreased by 15%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
 <br/>
-=== Mastodon &ndash; craftable as any armour ===
-<span style='color:#808080'><i>You will need a lot of hits to strike down a mastodon.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal and 3 Pearls</span><br/>
+=== Mask of the Demiurge &ndash; helm ===
+<span style='color:#808080'><i>Souls and magic are crafted into a world that obeys strict laws.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#antimagic (INTENSITY)_.E2.80.93_resistance|antimagic (20)]]</span><br/>
 <br/>
 === Mental Sheath &ndash; helm ===
 <span style='color:#808080'><i>You can never touch my spirit, you can never catch my soul.</i></span><br/>
@@ -1489,27 +1965,9 @@ and saved the righteous.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
 <br/>
-=== Merciless Wake &ndash; boots ===
-<span style='color:#808080'><i>Why so much hurry? Go slowly, look around, contemplate, kill whatever you like...</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage increased by 5</span><br/>
-<span style='color:#60A0FF'>2 fewer movement points</span><br/>
-<br/>
-=== Mighty Gauntlets &ndash; gauntlets ===
-<span style='color:#808080'><i>Like any other visitor, he put his sword on a rack outside. His mighty fists were deadly enough.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage increased by 2 (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<br/>
-=== Misanthropia &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>I have seen pillagers raping children. The worst of monsters are humans. They must be smitten.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misanthropia_.E2.80.93_damage|misanthropia]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misnania_.E2.80.93_damage|misnania]]</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Pearl, 2 Diamonds and 1 Emerald</span><br/>
+=== Mind Assisting Element &ndash; helm ===
+<span style='color:#808080'><i>This soulless clockwork wonder seems to somehow have a mind of its own.</i></span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 15%</span><br/>
 <br/>
 === Misery's Crown &ndash; helm ===
 <span style='color:#808080'><i>Do not bring your misery down on me.</i></span><br/>
@@ -1517,18 +1975,373 @@ and saved the righteous.</i></span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (15)]]</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#leeches_.E2.80.93_dummy|leech]]</span><br/>
 <br/>
-=== Mithral Armour &ndash; armour ===
-<span style='color:#808080'><i>This highly valuable armour is told to be made by dwarvish apprentices. I wonder what their masters make.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+=== Rherraent's Helm &ndash; helm ===
+<span style='color:#808080'><i>Look at your foes face to face,
+defeat your foes mace to face.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#Rherraent's Sword_.E2.80.93_sword|Rherraent's Sword]])</span><br/>
+<span style='color:purple'>12 more hitpoints (requires [[#Rherraent's Armour_.E2.80.93_armour|Rherraent's Armour]])</span><br/>
+<span style='color:purple'>12 more hitpoints (requires [[#Rherraent's Ring_.E2.80.93_ring|Rherraent's Ring]])</span><br/>
 <br/>
-=== Mithral Armour of Wrath &ndash; armour ===
-<span style='color:#808080'><i>Forged for the elite among Dwarvish Berserkers.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+=== Royal Diadem &ndash; helm ===
+<span style='color:#808080'><i>Even a fake king can lead soldiers into victory.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: royalty</span><br/>
+<br/>
+=== Shako &ndash; helm ===
+<span style='color:#808080'><i>Nobody would wear this helmet if it was not for its magic.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<br/>
+=== Static Float &ndash; helm ===
+<span style='color:#808080'><i>This one will be destroyed only at the end of times.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: submerge</span><br/>
+<br/>
+=== Steel Helmet &ndash; helm ===
+<span style='color:#808080'><i>'What is this thing good for?'
+'Nothing special.'</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
 <span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<br/>
+=== The Jester &ndash; helm ===
+<span style='color:#808080'><i>We needed better entertainment. They're in flames now.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 2%</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<br/>
+=== The Sick Face &ndash; helm ===
+<span style='color:#808080'><i>He looks sick. Killing him will be easy, just try not to catch whatever he has.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
+<span style='color:green'>New weapon special: poison (melee attacks only)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#radiation_.E2.80.93_dummy|radiation]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
+<span style='color:#60A0FF'>16 fewer hitpoints per level</span><br/>
+<br/>
+=== Virtual Void &ndash; helm ===
+<span style='color:#808080'><i>The pure shall be overridden.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 4</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<br/>
+=== Visions of Cruelty &ndash; helm ===
+<span style='color:#808080'><i>There is cruelty. As far as I can see, cruelty is everywhere.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 20% (in EASY difficulty), 15% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<br/>
+=== What no man should know &ndash; helm ===
+<span style='color:#808080'><i>I saw a man, frozen solid in a midsummer day. He had this pretty helmet, let me try it on...</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#frostbite_.E2.80.93_dummy|frostbite]]</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<br/>
+=== Wisdom of the Ages &ndash; helm ===
+<span style='color:#808080'><i>There is no ancient wisdom. Knowledge must be created in present.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Search for Wisdom_.E2.80.93_boots|Search for Wisdom]])</span><br/>
+<span style='color:purple'>+2 base damage (requires [[#Tracking the Lost Knowledge_.E2.80.93_cloak|Tracking the Lost Knowledge]])</span><br/>
+<br/>
+== knife ==
+=== Blade Juggler &ndash; knife ===
+<span style='color:#808080'><i>He threw a dozen knives into the air, catching and throwing them one by one.</i></span><br/>
+<span style='color:green'>Damage decreased by 25%</span><br/>
+<span style='color:green'>100% (in EASY difficulty), 85% (in MEDIUM difficulty), 70% (in HARD difficulty) more attacks</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<br/>
+=== Exterminator's Knives &ndash; knife ===
+<span style='color:#808080'><i>It may be hard to get close enough.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
+<span style='color:purple'>16 more hitpoints (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
+<br/>
+=== Exterminator's Knives &ndash; knife ===
+<span style='color:#808080'><i>It may be hard to get close enough.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
+<span style='color:purple'>16 more hitpoints (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
+<br/>
+=== Glowing Flight &ndash; knife ===
+<span style='color:#808080'><i>The pragmatic baron sent an assassin to kill a necromancer. It was not a bad idea.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:green'>40% more attacks</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<br/>
+=== Glowing Flight &ndash; knife ===
+<span style='color:#808080'><i>The pragmatic baron sent an assassin to kill a necromancer. It was not a bad idea.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:green'>40% more attacks</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<br/>
+=== Rigor Mortis &ndash; knife ===
+<span style='color:#808080'><i>Freeze! I need to aim!</i></span><br/>
+<span style='color:green'>Damage increased by 4 (in EASY difficulty), 3 (in MEDIUM difficulty), 2 (in HARD difficulty)</span><br/>
+<span style='color:green'>15% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
+<br/>
+=== Shredder &ndash; knife ===
+<span style='color:#808080'><i>Doing gruesome things to your enemies will enhance their fear and make them weak.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
+<br/>
+=== Soul Drinker &ndash; knife ===
+<span style='color:#808080'><i>The wounded assassin hid in the shadows. Only thrown knives could be seen. Then, he returned healthy.</i></span><br/>
+<span style='color:green'>Damage decreased by 20%</span><br/>
+<span style='color:green'>80% (in EASY difficulty), 65% (in MEDIUM difficulty), 50% (in HARD difficulty) more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
+<br/>
+=== Spectral Jet &ndash; knife ===
+<span style='color:#808080'><i>When you die, you should not expect your soul to go where you think it belongs.</i></span><br/>
+<span style='color:green'>Damage decreased by 20% (in EASY difficulty), 25% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Ghost)]]</span><br/>
+<br/>
+=== Spineripper &ndash; knife ===
+<span style='color:#808080'><i>Look at that exposed back.</i></span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:green'>New weapon special: backstab</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
+<br/>
+=== The Crusher &ndash; knife ===
+<span style='color:#808080'><i>I will send my assassins to slay the lich. You will gear them properly.</i></span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 45% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Sets damage type to impact</span><br/>
+<br/>
+=== The Shrapnel Knife &ndash; knife ===
+<span style='color:#808080'><i>I can hit all four of you with a single knife, hehe.</i></span><br/>
+<span style='color:green'>Damage increased by 45% (in EASY difficulty), 35% (in MEDIUM difficulty), 25% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== The Vile Knife &ndash; knife ===
+<span style='color:#808080'><i>Wounds heal, poison remains.</i></span><br/>
+<span style='color:green'>Damage increased by 25% (in EASY difficulty), 15% (in MEDIUM difficulty), 5% (in HARD difficulty)</span><br/>
+<span style='color:green'>40% more attacks</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#greater backstab_.E2.80.93_damage|greater backstab]]</span><br/>
+<br/>
+== limited ==
+=== Al-Fuṣūl wa al-ghāyāt &ndash; limited ===
+<span style='color:#808080'><i>They would not have accepted a spoken lie,
+but whips were raised to strike them,
+traditions were brought to them.</i></span><br/>
+<span style='color:purple'>10% to arcane resistance (requires [[#Theophrastus Redivivus_.E2.80.93_limited|Theophrastus Redivivus]])</span><br/>
+<span style='color:purple'>New ability: frail tide (10) (requires [[#Treatise of the Three Impostors_.E2.80.93_limited|Treatise of the Three Impostors]])</span><br/>
+<br/>
+=== Blue orb of dragonflame &ndash; limited ===
+<span style='color:#808080'><i>'Have you ever seen something like this?'
+'No, I will never see anything like this.'</i></span><br/>
+<span style='color:green'>2 more attacks</span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
+<br/>
+=== Book of Courage &ndash; limited ===
+<span style='color:#808080'><i>Daniel was looking for this book. But it was in a dark corner.</i></span><br/>
+<span style='color:green'>Unit becomes fearless</span><br/>
+<br/>
+=== Book of Fireballs &ndash; limited ===
+<span style='color:#808080'><i>Burn, incinerate, scorch, see your foes turn to ash.</i></span><br/>
+<span style='color:orange'>New advancements: Casting fireballs, from basic casting to explosive damages</span><br/>
+<br/>
+=== Book of Herbal Tinctures and Malignancies &ndash; limited ===
+<span style='color:#808080'><i>Like real cures are not needed to get payment for healing, real poison is not needed to harm.</i></span><br/>
+<span style='color:orange'>New advancements: Poisons and cures</span><br/>
+<br/>
+=== Book of Magical Swordplay &ndash; limited ===
+<span style='color:#808080'><i>It is not strength or motivation that makes a great warrior. It is the skill.</i></span><br/>
+<span style='color:orange'>New advancements: Fencing techniques, offensive and also defensive</span><br/>
+<br/>
+=== Glitch Item &ndash; limited ===
+<span style='color:#808080'><i>Everything can fail. Regardless of the amount of polishing done.</i></span><br/>
+<span style='color:red'>New obligation: Report this bug on the forums</span><br/>
+<br/>
+=== Guide to Lycanthropy &ndash; limited ===
+<span style='color:#808080'><i>Search your memories and find the monster you are.</i></span><br/>
+<span style='color:orange'>New advancements: Abilities that allow a transformation into powerful animal forms</span><br/>
+<br/>
+=== Heart of Darkness &ndash; limited ===
+<span style='color:#808080'><i>Find your dark subconscience and embrace it.</i></span><br/>
+<span style='color:orange'>New advancements: Various wicked spells</span><br/>
+<br/>
+=== How to be an Overlord &ndash; limited ===
+<span style='color:#808080'><i>Attack! Attack! Attack!</i></span><br/>
+<span style='color:orange'>New advancements: Leadership-like abilities</span><br/>
+<br/>
+=== Koschei's Journal &ndash; limited ===
+<span style='color:#808080'><i>The princess asked him where his soul was hidden. The prince found it.</i></span><br/>
+<span style='color:orange'>New advancements: Powerful improvements to spells</span><br/>
+<br/>
+=== Orb of Demonic Wrath &ndash; limited ===
+<span style='color:#808080'><i>Live for the spite, serve the rage, love the hate, drink the anger, embrace the loathing,
+pet the resentment, enjoy the scorning, cuddle the abhorrence, kiss all the foul.</i></span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<br/>
+=== Raijer's Bloody Field &ndash; limited ===
+<span style='color:#808080'><i>Those who are the first of their kinds are often the mightiest of them.</i></span><br/>
+<span style='color:orange'>New advancements: Techniques of extracting the victims's soul and using it for own profit</span><br/>
+<br/>
+=== Serendipity &ndash; limited ===
+<span style='color:#808080'><i>'Some inventions come out of nowhere.' - Kevla the Saviour</i></span><br/>
+<span style='color:orange'>New advancements: You never know what will be learned from here</span><br/>
+<br/>
+=== The Doctrine of Vindictiveness &ndash; limited ===
+<span style='color:#808080'><i>If they attack you, make sure they will not dare or will not exist to attack again.</i></span><br/>
+<span style='color:orange'>New advancements: A distinctively vindictive view on combat</span><br/>
+<br/>
+=== The Fencer's Study &ndash; limited ===
+<span style='color:#808080'><i>Do you think fencing takes a lot of time to learn? Just buy this for 20 gold and see how easy it is!</i></span><br/>
+<span style='color:orange'>New advancements: Quick mastery of fencing</span><br/>
+<br/>
+=== The Infidel &ndash; limited ===
+<span style='color:#808080'><i>Fidel is dead. Hail the Infidel.</i></span><br/>
+<span style='color:#60A0FF'>Sets alignment to neutral</span><br/>
+<br/>
+=== Theophrastus Redivivus &ndash; limited ===
+<span style='color:#808080'><i>Difficile est negave Deos, si inconcione quaratur, sed in familliarium, sermone, en consessur facilitimum...</i></span><br/>
+<span style='color:purple'>10% to arcane resistance (requires [[#Treatise of the Three Impostors_.E2.80.93_limited|Treatise of the Three Impostors]])</span><br/>
+<span style='color:purple'>New ability: regenerates slightly (requires [[#Al-Fuṣūl wa al-ghāyāt_.E2.80.93_limited|Al-Fuṣūl wa al-ghāyāt]])</span><br/>
+<br/>
+=== Tome of Bards &ndash; limited ===
+<span style='color:#808080'><i>Stand up and fight
+Stand up and see the sky turn bright</i></span><br/>
+<span style='color:orange'>New advancements: Techniques of inspiring allies to deal more damage</span><br/>
+<br/>
+=== Tome of Bards, Volume II &ndash; limited ===
+<span style='color:#808080'><i>Shining and so glorious
+The bloodline of true warriors</i></span><br/>
+<span style='color:orange'>New advancements: Techniques of inspiring allies to fight better and annoying enemies</span><br/>
+<br/>
+=== Tome of Liches &ndash; limited ===
+<span style='color:#808080'><i>Are you fed up of mortality?</i></span><br/>
+<span style='color:orange'>New advancements: Teachings of the dark arts of necromancy</span><br/>
+<br/>
+=== Tome of Liches &ndash; limited ===
+<span style='color:#808080'><i>Are you fed up of mortality?</i></span><br/>
+<span style='color:orange'>New advancements: Teachings of the dark arts of necromancy</span><br/>
+<br/>
+=== Treatise of the Three Impostors &ndash; limited ===
+<span style='color:#808080'><i>However important it may be for all men to know the Truth, very few, nevertheless, are acquainted with it...</i></span><br/>
+<span style='color:purple'>10% to arcane resistance (requires [[#Theophrastus Redivivus_.E2.80.93_limited|Theophrastus Redivivus]])</span><br/>
+<span style='color:purple'>New ability: exile (requires [[#Al-Fuṣūl wa al-ghāyāt_.E2.80.93_limited|Al-Fuṣūl wa al-ghāyāt]])</span><br/>
+<br/>
+=== Wrathful Combat Techniques &ndash; limited ===
+<span style='color:#808080'><i>Let the anger flow through your veins.</i></span><br/>
+<span style='color:orange'>New advancements: Techniques of using anger in battle</span><br/>
+<br/>
+== mace ==
+=== Beelzebub's Hammer &ndash; mace ===
+<span style='color:#808080'><i>Where is Bruce gone?</i></span><br/>
+<span style='color:green'>Damage increased by 10% (in EASY difficulty), 25% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#lord of the flies_.E2.80.93_damage|lord of the flies]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<br/>
+=== Despicable Heroism &ndash; mace ===
+<span style='color:#808080'><i>Your deeds are revered, but the way you do them is damned.</i></span><br/>
+<span style='color:green'>Damage decreased by 40% (in EASY difficulty), 50% (in MEDIUM difficulty), 55% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Revenant)]]</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 5%</span><br/>
+<br/>
+=== Despicable Heroism &ndash; mace ===
+<span style='color:#808080'><i>Your deeds are revered, but the way you do them is damned.</i></span><br/>
+<span style='color:green'>Damage decreased by 20% (in EASY difficulty), 30% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Revenant)]]</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 5%</span><br/>
+<br/>
+=== Eternity's End &ndash; mace ===
+<span style='color:#808080'><i>Even lich lords cannot live forever.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:green'>Enemy resistances to blade decreased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Fist of Anarchy &ndash; mace ===
+<span style='color:#808080'><i>Rebirth through devastation, freedom through bloodshed.</i></span><br/>
+<span style='color:green'>60% (in EASY difficulty), 50% (in MEDIUM difficulty), 40% (in HARD difficulty) more attacks</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anarchy_.E2.80.93_damage|anarchy]]</span><br/>
+<br/>
+=== Fleshrending Scourge &ndash; mace ===
+<span style='color:#808080'><i>Do not run away from me. I will catch you anyway.</i></span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 40% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to impact decreased by 10%</span><br/>
+<span style='color:#60A0FF'>2 more movement points</span><br/>
+<br/>
+=== Godsmasher &ndash; mace ===
+<span style='color:#808080'><i>'With this beast, I can kill even a god!'
+'Crunch, munch,... burp. Anybody else thinks that it can kill dragons too?'</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:green'>Enemy resistances to impact decreased by 20%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
+<br/>
+=== Godsmasher &ndash; mace ===
+<span style='color:#808080'><i>'With this beast, I can kill even a god!'
+'Crunch, munch,... burp. Anybody else thinks that it can kill dragons too?'</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:green'>Enemy resistances to impact decreased by 20%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
+<br/>
+=== Gvødgührvoḧzzorghkuz &ndash; mace ===
+<span style='color:#808080'><i>Ürhrabgzubruprÿÿrv øẗhnäæzdaz grohruth züürd myyvöthgavrhyd...</i></span><br/>
+<span style='color:green'>30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
+<br/>
+=== Heathenbasher &ndash; mace ===
+<span style='color:#808080'><i>Dark is the night that has set to your mind, sweet is the pride that reflects in your eyes.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#lawful_.E2.80.93_damage|lawful]]</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: illuminates</span><br/>
+<br/>
+=== Jawbreaker &ndash; mace ===
+<span style='color:#808080'><i>Why are you grinning like that? It could have killed you!</i></span><br/>
+<span style='color:green'>Damage decreased by 10% (in EASY difficulty), 20% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
+<br/>
+=== Lilith's Old Precious &ndash; mace ===
+<span style='color:#808080'><i>In order to be able to fight with any weapon available, Lilith swaps weapon types once per century.</i></span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty) more attacks</span><br/>
+<span style='color:#60A0FF'>20% chance to strike a devastating blow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#dazzle_.E2.80.93_dummy|dazzle]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#60A0FF'>24 more hitpoints per level</span><br/>
 <br/>
 === Morgenstern &ndash; mace ===
 <span style='color:#808080'><i>The star of dawn will smash your face.</i></span><br/>
@@ -1537,154 +2350,171 @@ and saved the righteous.</i></span><br/>
 <span style='color:green'>New weapon special: magical</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#twilightstalk_.E2.80.93_hides|twilightstalk]]</span><br/>
 <br/>
-=== Morok's Armour &ndash; armour ===
-<span style='color:#808080'><i>Fear the one who calls himself a god of war.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 17%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== Morrígan's Slasher &ndash; axe ===
-<span style='color:#808080'><i>Why do these heathens believe that there can be a <b>goddess</b> of war?</i></span><br/>
-<span style='color:green'>Damage increased by 50%</span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
-<br/>
-=== Mother de Rais &ndash; staff ===
-<span style='color:#808080'><i>The undead were too numerous to be burned by her fireballs. She had to jump into a river far below to save herself.</i></span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Movement costs in shallow waters set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on coastal reefs set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through swampy places set to 1</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== Mountain Trek &ndash; boots ===
-<span style='color:#808080'><i>'It will take us months to pass through these mountains!'
-'I will wait for you on the other side.'</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on mountains set to 1</span><br/>
-<br/>
-=== Murderlust &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Killing makes you stronger, why should you stop doing it?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#penetrates_.E2.80.93_dummy|penetrates]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 3 Pearls, 1 Diamond, 1 Ruby and 2 Emeralds</span><br/>
-<br/>
-=== Mystic Armour &ndash; armour ===
-<span style='color:#808080'><i>Forged at unknown location who knows when.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<br/>
-=== Mystic Armour of the Untouchable &ndash; armour ===
-<span style='color:#808080'><i>Body count matters. I will better let that evasive and well armoured warrior for others.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<br/>
-=== Mystic Occult Armour of Carpathia &ndash; armour ===
-<span style='color:#808080'><i>Psychospiritual mysticism leads to nocturnal blackness.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 30%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<br/>
-=== Nightstalker &ndash; dagger ===
-<span style='color:#808080'><i>That looming darkness is a herald of his arrival. Somebody will die very soon.</i></span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#greater backstab_.E2.80.93_damage|greater backstab]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens_.E2.80.93_illuminates|darkens]]</span><br/>
-<span style='color:#60A0FF'>New ability: nightstalk</span><br/>
-<br/>
-=== Nighwalker &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Black and transparent</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians and 1 Opal</span><br/>
-<br/>
-=== Nocturnal Cloak &ndash; cloak ===
-<span style='color:#808080'><i>You merely adopted darkness, I was molded by it.</i></span><br/>
-<span style='color:green'>New weapon special: backstab (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
-<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
-<br/>
-=== Obsidian &ndash; gem ===
-<span style='color:#808080'><i>Although this gem looks interesting in appearance, its magical power is limited. However, in combination with other gems, it can find some use.</i></span><br/>
-<br/>
-=== Odin's Spear &ndash; spear ===
-<span style='color:#808080'><i>Odin was a warrior, but every winter solstice, he came and brought gifts to kids.</i></span><br/>
-<span style='color:green'>Damage increased by 50%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to drain_.E2.80.93_dummy|immune to drain]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
-<br/>
-=== Opal &ndash; gem ===
-<span style='color:#808080'><i>This is the least rare of precious gems, but it can be still used to craft useful items.</i></span><br/>
-<br/>
-=== Orb of Demonic Wrath &ndash; limited ===
-<span style='color:#808080'><i>Live for the spite, serve the rage, love the hate, drink the anger, embrace the loathing,
-pet the resentment, enjoy the scorning, cuddle the abhorrence, kiss all the foul.</i></span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
-<br/>
 === Organ Grinder &ndash; mace ===
 <span style='color:#808080'><i>Keep that man away from me... Hey, keep him away! Do not flee! Aaarghh! Ehhmragehhhd...</i></span><br/>
 <span style='color:green'>Damage increased by 8 (in EASY difficulty), 6 (in MEDIUM difficulty), 4 (in HARD difficulty)</span><br/>
 <span style='color:green'>New weapon special: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
 <span style='color:green'>New weapon special: [[LotI_Abilities#lethargy_.E2.80.93_dummy|lethargy]]</span><br/>
 <br/>
+=== Preacher of Hatred &ndash; mace ===
+<span style='color:#808080'><i>Your descendants, ancestors and friends are demonic kin that is behind all our suffering.</i></span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#hate speech_.E2.80.93_dummy|hate speech]]</span><br/>
+<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+<br/>
+=== Righteous Cause &ndash; mace ===
+<span style='color:#808080'><i>Once he starts attacking, you cannot stop him. You can only run.</i></span><br/>
+<span style='color:green'>Damage increased by 8 (in EASY difficulty), 6 (in MEDIUM difficulty), 5 (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#zeal_.E2.80.93_resistance|zeal]]</span><br/>
+<br/>
+=== Sceptre of Antipater &ndash; mace ===
+<span style='color:#808080'><i>You can be evil even if you heal people.</i></span><br/>
+<span style='color:#60A0FF'>20% chance to strike a devastating blow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic_.E2.80.93_damage|chaotic]]</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#heals +VALUE_.E2.80.93_heals|heals (16)]]</span><br/>
+<br/>
+=== Sceptre of the King &ndash; mace ===
+<span style='color:#808080'><i>The sceptre was the symbol of king's power. Using it as a weapon did not stop the assassin.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:purple'>New Ability: radiation (requires [[#Crown of the King_.E2.80.93_helm|Crown of the King]])</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Armour of the King_.E2.80.93_armour|Armour of the King]])</span><br/>
+<span style='color:purple'>+2 to base damage (requires [[#Ring of the King_.E2.80.93_ring|Ring of the King]])</span><br/>
+<br/>
+=== The Disease and the Cure &ndash; mace ===
+<span style='color:#808080'><i>You are the disease. We are the cure.</i></span><br/>
+<span style='color:green'>Damage increased by 6 (in EASY difficulty), 5 (in MEDIUM difficulty), 4 (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (25)]]</span><br/>
+<br/>
+=== The Fighting Bull &ndash; mace ===
+<span style='color:#808080'><i>Takes a blink of an eye to anger, takes a day to calm down.</i></span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#triggerable_.E2.80.93_dummy|triggerable]]</span><br/>
+<br/>
+=== The Great Truth &ndash; mace ===
+<span style='color:#808080'><i>The Great Truth is that there is no Great Truth.</i></span><br/>
+<span style='color:green'>Damage increased by 14 (in EASY difficulty), 12 (in MEDIUM difficulty), 10 (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== The Unstoppable &ndash; mace ===
+<span style='color:#808080'><i>No one can bargain with him. There is no way to reason with him. He feels no fear. There is nothing at all that would stop him... until the evil is banished.</i></span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#resistant to slow_.E2.80.93_dummy|resistant to slow]]</span><br/>
+<br/>
+=== Tormentor of Light &ndash; mace ===
+<span style='color:#808080'><i>In the absence of light, darkness and disorder rules.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic_.E2.80.93_damage|chaotic]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens_.E2.80.93_illuminates|darkens]]</span><br/>
+<br/>
+=== Unrighteous Cause &ndash; mace ===
+<span style='color:#808080'><i>Avoid hitting too hard, it will defeat the enemy too fast and take away the fun.</i></span><br/>
+<span style='color:green'>Damage decreased by 4</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 30%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
+<br/>
+=== Wrath of the Pagan &ndash; mace ===
+<span style='color:#808080'><i>Law or chaos? That is just a point of view not everyone shares.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic and lawful_.E2.80.93_damage|chaotic and lawful]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<br/>
+=== Wrath of the Pagan &ndash; mace ===
+<span style='color:#808080'><i>Law or chaos? That is just a point of view not everyone shares.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic and lawful_.E2.80.93_damage|chaotic and lawful]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<br/>
+== polearm ==
+=== Exterminator's Scythe &ndash; polearm ===
+<span style='color:#808080'><i>Victims' loyals look for revenge.</i></span><br/>
+<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:green'>35% more attacks</span><br/>
+<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
+<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
+<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
+<br/>
+=== Exterminator's Scythe &ndash; polearm ===
+<span style='color:#808080'><i>Victims' loyals look for revenge.</i></span><br/>
+<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
+<span style='color:green'>35% more attacks</span><br/>
+<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
+<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
+<span style='color:purple'>+1 to base damage (requires [[#Exterminator's Ring_.E2.80.93_ring|Exterminator's Ring]])</span><br/>
+<br/>
+=== Xuanquang's Soul Harvest &ndash; polearm ===
+<span style='color:#808080'><i>Don't be afraid when seeing a bloody road. Keep calm and turn back to face the one who made it so bloody.</i></span><br/>
+<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>Merges attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#kamikaze sprint_.E2.80.93_damage|kamikaze sprint]]</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+== potion ==
+=== Bloodsucker's Potion &ndash; potion ===
+<span style='color:#808080'><i>All this blood. It is yours. You will drink it. You will guzzle it. You will choke on it. You will drown in it.</i></span><br/>
+<span style='color:green'>New weapon special (ranged attacks only): drain</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#blood drinking_.E2.80.93_dummy|blood drinking]]</span><br/>
+<br/>
+=== Creepy Potion &ndash; potion ===
+<span style='color:#808080'><i>If you hear me better fear me, if you see me better flee me.</i></span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (20)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
+<br/>
+=== Fire-Forged Friend &ndash; potion ===
+<span style='color:#808080'><i>'I make my friends with hammer and anvil.' -Pygmaliophaestus</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 50%</span><br/>
+<span style='color:#60A0FF'>4 fewer movement points</span><br/>
+<br/>
+=== Foul Potion &ndash; potion ===
+<span style='color:#808080'><i>It helps us greatly, but its user pays a great price.</i></span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unholy hunger_.E2.80.93_dummy|unholy hunger]]</span><br/>
+<br/>
+=== Greater Healing Potion &ndash; potion ===
+<span style='color:#808080'><i>This can heal almost anyone, find the one who brewed it!</i></span><br/>
+<span style='color:orange'>This unit is completely restored, including statuses, moves and attacks.</span><br/>
+<br/>
+=== Healing Potion &ndash; potion ===
+<span style='color:#808080'><i>I am healed! More healthy than ever!</i></span><br/>
+<span style='color:#60A0FF'>10 more hitpoints per level</span><br/>
+<span style='color=#60A0FF'>Full heal</span><br/>
+<br/>
+=== Holy potion &ndash; potion ===
+<span style='color:#808080'><i>Grrrh! Remove this filth from this world! Rrrargh!</i></span><br/>
+<span style='color:green'>New weapon special (melee attacks only): [[LotI_Abilities#unholybane_.E2.80.93_damage|unholybane]]</span><br/>
+<br/>
+=== Lesser Potion of Invisibility &ndash; potion ===
+<span style='color:#808080'><i>When you are defeated, search for solace in the darkness.</i></span><br/>
+<span style='color:#60A0FF'>New ability: nightstalk</span><br/>
+<br/>
 === Otherworldy Cinders &ndash; potion ===
 <span style='color:#808080'><i>Arise, the bird of death, burn when you die and reappear from your flames.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 40%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#from the ashes_.E2.80.93_dummy|from the ashes]]</span><br/>
-<br/>
-=== Paranoia &ndash; cloak ===
-<span style='color:#808080'><i>Every face is an enemy.</i></span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#forsaken_.E2.80.93_resistance|forsaken]]</span><br/>
-<br/>
-=== Pearl &ndash; gem ===
-<span style='color:#808080'><i>This is one of the few kinds of precious gems that are grown, and not created by volcanic or tectonic processes. It has a wide use in decorating things or granting them magical properties.</i></span><br/>
-<br/>
-=== Perfection &ndash; craftable as any armour ===
-<span style='color:#808080'><i>I am from a perfect breed. Orcs are so low-born, they must be exterminated.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#misorcia_.E2.80.93_damage|misorcia]]</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 20%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 1 Opal, 1 Diamond and 2 Rubies</span><br/>
 <br/>
 === Poison &ndash; potion ===
 <span style='color:#808080'><i>Why is this technique a taboo?</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): poison</span><br/>
 <span style='color:green'>New weapon special (ranged pierce attacks only): poison</span><br/>
 <br/>
-=== Poisonous Bow &ndash; bow ===
-<span style='color:#808080'><i>Please stop focusing on one enemy.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>35% more attacks</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<br/>
 === Potion of Authority &ndash; potion ===
 <span style='color:#808080'><i>One gulp to rule them all!</i></span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership_.E2.80.93_leadership|leadership]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 6 unit)]]</span><br/>
 <br/>
 === Potion of Mundanity &ndash; potion ===
 <span style='color:#808080'><i>What if magic was just a nocebo?</i></span><br/>
@@ -1711,29 +2541,69 @@ pet the resentment, enjoy the scorning, cuddle the abhorrence, kiss all the foul
 <br/>
 === Potion of Titanic Strength &ndash; potion ===
 <span style='color:#808080'><i>Cronus was the mightiest of the Titans. Only a fraction of his strength is devastating.</i></span><br/>
-<span style='color:green'>Damage increased by 10 (melee attacks only)</span><br/>
+<span style='color:orange'>Increases all melee damages by 10</span><br/>
 <br/>
 === Potion of Vitality &ndash; potion ===
 <span style='color:#808080'><i>A new life flows in the veins of those who drink this brew.</i></span><br/>
-<span style='color=#60A0FF'>Full heal</span><br/>
 <span style='color:#60A0FF'>New ability: regenerates</span><br/>
 <br/>
-=== Prayer &ndash; craftable as any armour ===
-<span style='color:#808080'><i>'I feel sick, can you help me?'
-'No, but I shall pray for you.'</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<span style='color:#60A0FF'>New ability: cures</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Opal, 3 Pearls, 3 Diamonds and 2 Rubies</span><br/>
+=== Spirits of a Madman's Alacrity &ndash; potion ===
+<span style='color:#808080'><i>Are you sane? You cannot fight so much, we will run out of enemies too soon!</i></span><br/>
+<span style='color:orange'>1 extra attack per turn</span><br/>
 <br/>
-=== Preacher of Hatred &ndash; mace ===
-<span style='color:#808080'><i>Your descendants, ancestors and friends are demonic kin that is behind all our suffering.</i></span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#hate speech_.E2.80.93_dummy|hate speech]]</span><br/>
-<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
+=== Stolen Potion &ndash; potion ===
+<span style='color:#808080'><i>I have stolen this. Now all the word is here for me to steal.</i></span><br/>
+<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#steals_.E2.80.93_dummy|steals]]</span><br/>
+<br/>
+=== Virulent Poison &ndash; potion ===
+<span style='color:#808080'><i>He is not only farting poison, he also sweats and burps it.</i></span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
+<br/>
+== ring ==
+=== Angel of Death's Ring &ndash; ring ===
+<span style='color:#808080'><i>Death is the end, but sometimes an end is needed.</i></span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 7%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 7%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 7%</span><br/>
+<span style='color:purple'>+12 to hitpoints (requires [[#Cloak of the Pale Rider_.E2.80.93_cloak|Cloak of the Pale Rider]])</span><br/>
+<span style='color:purple'>5% to all resistances (requires [[#Amulet of the Last Guide_.E2.80.93_amulet|Amulet of the Last Guide]])</span><br/>
+<br/>
+=== Dazzling Ring &ndash; ring ===
+<span style='color:#808080'><i>You were born to die blind.</i></span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#dazzle_.E2.80.93_dummy|dazzle]]</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<br/>
+=== Eidolon's Ring &ndash; ring ===
+<span style='color:#808080'><i>When he was old and dying, he remembered what he could from the days he loved a necromanceress.</i></span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
+<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
+<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
+<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
+<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
+<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
+<span style='color:purple'>New ability: Deathaura (8) (requires [[#Eidolon's Sword_.E2.80.93_sword|Eidolon's Sword]])</span><br/>
+<br/>
+=== Exterminator's Ring &ndash; ring ===
+<span style='color:#808080'><i>Hide from the revolution.</i></span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
+<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
+<br/>
+=== Exterminator's Ring &ndash; ring ===
+<span style='color:#808080'><i>Hide from the revolution.</i></span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
+<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Scythe_.E2.80.93_polearm|Exterminator's Scythe]])</span><br/>
+<span style='color:purple'>+1 to base ranged damage (requires [[#Exterminator's Dagger_.E2.80.93_dagger|Exterminator's Dagger]])</span><br/>
+<span style='color:purple'>2% to all resistances (requires [[#Exterminator's Knives_.E2.80.93_knife|Exterminator's Knives]])</span><br/>
 <br/>
 === Precious Eagle Cactus Fruit &ndash; ring ===
 <span style='color:#808080'><i>I need sacrifice. Be it involuntary or not.</i></span><br/>
@@ -1743,30 +2613,6 @@ pet the resentment, enjoy the scorning, cuddle the abhorrence, kiss all the foul
 <span style='color:#60A0FF'>Resistance to arcane decreased by 20%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#heals +VALUE_.E2.80.93_heals|heals (40)]]</span><br/>
 <br/>
-=== Prismatic Iron Armour &ndash; armour ===
-<span style='color:#808080'><i>This armour was made to kill wizards, so do not expect it to save you from deadly blades.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 13%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== Purity &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Glory of the pure led the nocturnal creatures away.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#improved illumination_.E2.80.93_illuminates|improved illumination]]</span><br/>
-<span style='color:#60A0FF'>Sets alignment to lawful</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 4 Topazes, 2 Diamonds and 1 Amethyst</span><br/>
-<br/>
-=== Pyromancer's Cloak &ndash; cloak ===
-<span style='color:#808080'><i>When his body was destroyed, he rose again from the ashes.</i></span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:purple'>5% to magical resistances (requires [[#Pyromancer's Sword_.E2.80.93_sword|Pyromancer's Sword]])</span><br/>
-<span style='color:purple'>New ability: from the ashes (requires [[#Pyromancer's Ring_.E2.80.93_ring|Pyromancer's Ring]])</span><br/>
-<br/>
 === Pyromancer's Ring &ndash; ring ===
 <span style='color:#808080'><i>He could feed on fire and magic, spitting it back on those who tried to harm him with it.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
@@ -1775,106 +2621,11 @@ pet the resentment, enjoy the scorning, cuddle the abhorrence, kiss all the foul
 <span style='color:purple'>New attack: fireball (11-4 fire damage, magical) (requires [[#Pyromancer's Sword_.E2.80.93_sword|Pyromancer's Sword]])</span><br/>
 <span style='color:purple'>Damage increased by 2 (requires [[#Pyromancer's Cloak_.E2.80.93_cloak|Pyromancer's Cloak]])</span><br/>
 <br/>
-=== Pyromancer's Sword &ndash; sword ===
-<span style='color:#808080'><i>Flames were his nature, they replaced his insides.</i></span><br/>
-<span style='color:green'>Damage increased by 20% (in EASY difficulty), -10% (in MEDIUM difficulty), -40% (in HARD difficulty)</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:purple'>New ability: firecast (requires [[#Pyromancer's Ring_.E2.80.93_ring|Pyromancer's Ring]])</span><br/>
-<span style='color:purple'>5% to magical resistances (requires [[#Pyromancer's Cloak_.E2.80.93_cloak|Pyromancer's Cloak]])</span><br/>
-<br/>
-=== Quick Gauntlets &ndash; gauntlets ===
-<span style='color:#808080'><i>Quick hands are the best defence.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:green'>Increases all magical damages by 5%</span><br/>
-<br/>
-=== Quintessence &ndash; craftable as any armour ===
-<span style='color:#808080'><i>'All is made of four elements.'
-'Master, four is not a pretty number. Why not five?'
-'Very well, I was testing you. There is a fifth element.'</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:purple'>New ability: regenerates (requires [[#The Essence of Magic_.E2.80.93_craftable as any weapon|The Essence of Magic]])</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 3 Opals, 1 Ruby, 2 Emeralds and 1 Amethyst</span><br/>
-<br/>
-=== Raijer's Bloody Field &ndash; limited ===
-<span style='color:#808080'><i>Those who are the first of their kinds are often the mightiest of them.</i></span><br/>
-<span style='color:orange'>New advancements: Techniques of extracting the victims's soul and using it for own profit</span><br/>
-<br/>
-=== Rationality &ndash; gauntlets ===
-<span style='color:#808080'><i>Magic is just very well made quackery.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Sets damage type to blade</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
-<br/>
-=== Redshirt Armour &ndash; armour ===
-<span style='color:#808080'><i>Why do they all try to kill that man?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
-<br/>
-=== Relentless Fury &ndash; xbow ===
-<span style='color:#808080'><i>You tell that my hits are weak? I will show you how many of them you can survive, nothing can stop me!</i></span><br/>
-<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
-<span style='color:green'>120% (in EASY difficulty), 100% (in MEDIUM difficulty), 80% (in HARD difficulty) more attacks</span><br/>
-<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
-<br/>
-=== Return to the Tribe &ndash; spear ===
-<span style='color:#808080'><i>I may be no better, but at least I am different.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty) more attacks</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
-<br/>
-=== Rherraent's Armour &ndash; armour ===
-<span style='color:#808080'><i>Shiny armour will only attract unwanted attention.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#Rherraent's Sword_.E2.80.93_sword|Rherraent's Sword]])</span><br/>
-<span style='color:purple'>3% to all resistances (requires [[#Rherraent's Helm_.E2.80.93_helm|Rherraent's Helm]])</span><br/>
-<span style='color:purple'>3% to all resistances (requires [[#Rherraent's Ring_.E2.80.93_ring|Rherraent's Ring]])</span><br/>
-<br/>
-=== Rherraent's Helm &ndash; helm ===
-<span style='color:#808080'><i>Look at your foes face to face,
-defeat your foes mace to face.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#Rherraent's Sword_.E2.80.93_sword|Rherraent's Sword]])</span><br/>
-<span style='color:purple'>12 more hitpoints (requires [[#Rherraent's Armour_.E2.80.93_armour|Rherraent's Armour]])</span><br/>
-<span style='color:purple'>12 more hitpoints (requires [[#Rherraent's Ring_.E2.80.93_ring|Rherraent's Ring]])</span><br/>
-<br/>
 === Rherraent's Ring &ndash; ring ===
 <span style='color:#808080'><i>His poor widow sold his property bit by bit, and they lost their power.</i></span><br/>
 <span style='color:green'>Enemy resistances to blade decreased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
 <span style='color:purple'>New Ability: regenerates (requires [[#Rherraent's Sword_.E2.80.93_sword|Rherraent's Sword]])</span><br/>
-<br/>
-=== Rherraent's Sword &ndash; sword ===
-<span style='color:#808080'><i>In his hands, the sword was a formidable weapon. In the hands of its thief, it was useless.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:purple'>+2 to base melee damage (requires [[#Rherraent's Armour_.E2.80.93_armour|Rherraent's Armour]])</span><br/>
-<span style='color:purple'>+2 to base melee damage (requires [[#Rherraent's Helm_.E2.80.93_helm|Rherraent's Helm]])</span><br/>
-<span style='color:purple'>+2 to base melee damage (requires [[#Rherraent's Ring_.E2.80.93_ring|Rherraent's Ring]])</span><br/>
-<br/>
-=== Righteous Cause &ndash; mace ===
-<span style='color:#808080'><i>Once he starts attacking, you cannot stop him. You can only run.</i></span><br/>
-<span style='color:green'>Damage increased by 8 (in EASY difficulty), 6 (in MEDIUM difficulty), 5 (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#zeal_.E2.80.93_resistance|zeal]]</span><br/>
-<br/>
-=== Rigor Mortis &ndash; knife ===
-<span style='color:#808080'><i>Freeze! I need to aim!</i></span><br/>
-<span style='color:green'>Damage increased by 4 (in EASY difficulty), 3 (in MEDIUM difficulty), 2 (in HARD difficulty)</span><br/>
-<span style='color:green'>15% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
 <br/>
 === Ring of Deathaura &ndash; ring ===
 <span style='color:#808080'><i>A harbinger of death from the world of witchcraft.</i></span><br/>
@@ -1921,7 +2672,15 @@ defeat your foes mace to face.</i></span><br/>
 <span style='color:#808080'><i>Warriors were no match for him. He was no match for wizards.</i></span><br/>
 <span style='color:green'>Damage increased by 40%</span><br/>
 <span style='color:green'>1 more attacks</span><br/>
-<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to fire decreased by 30%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold decreased by 30%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane decreased by 30%</span><br/>
+<br/>
+=== Ring of Unearthly Existence &ndash; ring ===
+<span style='color:#808080'><i>Warriors were no match for him. He was no match for wizards.</i></span><br/>
+<span style='color:green'>Damage increased by 40%</span><br/>
+<span style='color:green'>1 more attacks</span><br/>
 <span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
 <span style='color:#60A0FF'>Resistance to fire decreased by 30%</span><br/>
 <span style='color:#60A0FF'>Resistance to cold decreased by 30%</span><br/>
@@ -1937,13 +2696,6 @@ defeat your foes mace to face.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
 <br/>
-=== Robes of Filth &ndash; cloak ===
-<span style='color:#808080'><i>You call my new shirt filth?! For the thirty dirty pins in the sleeves?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#infect_.E2.80.93_poison|infect]] (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
-<br/>
 === Rock Solid &ndash; ring ===
 <span style='color:#808080'><i>In halls of stone... walls are impassable.</i></span><br/>
 <span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
@@ -1951,110 +2703,103 @@ defeat your foes mace to face.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
 <br/>
-=== Royal Diadem &ndash; helm ===
-<span style='color:#808080'><i>Even a fake king can lead soldiers into victory.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: royalty</span><br/>
-<br/>
-=== Ruby &ndash; gem ===
-<span style='color:#808080'><i>This is a diamond containing other minerals, that make its colour bright red. Its magical power is strong, and it can be used to create powerful magical things.</i></span><br/>
-<br/>
-=== Sapphire &ndash; gem ===
-<span style='color:#808080'><i>This incredibly rare colour variation is highly sought after for its incredible magical power.</i></span><br/>
-<br/>
-=== Scaryface &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Behold my countenance and tremble!</i></span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
-<span style='color:#60A0FF'>Resistance to fire decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 40%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal, 1 Amethyst and 1 Sapphire</span><br/>
-<br/>
-=== Sceptre of Antipater &ndash; mace ===
-<span style='color:#808080'><i>You can be evil even if you heal people.</i></span><br/>
-<span style='color:#60A0FF'>20% chance to strike a devastating blow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic_.E2.80.93_damage|chaotic]]</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#heals +VALUE_.E2.80.93_heals|heals (16)]]</span><br/>
-<br/>
-=== Sceptre of the King &ndash; mace ===
-<span style='color:#808080'><i>The sceptre was the symbol of king's power. Using it as a weapon did not stop the assassin.</i></span><br/>
-<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:purple'>New Ability: radiation (requires [[#Crown of the King_.E2.80.93_helm|Crown of the King]])</span><br/>
-<span style='color:purple'>+1 to base attacks (requires [[#Armour of the King_.E2.80.93_armour|Armour of the King]])</span><br/>
-<span style='color:purple'>+2 to base damage (requires [[#Ring of the King_.E2.80.93_ring|Ring of the King]])</span><br/>
-<br/>
-=== Scourge of All Living &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Stories talk about a disease that comes out of nowhere and no one can survive.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 30%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#cancer_.E2.80.93_dummy|cancer]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 1 Opal, 1 Pearl, 1 Diamond and 1 Emerald</span><br/>
-<br/>
-=== Search for Wisdom &ndash; boots ===
-<span style='color:#808080'><i>They look for wisdom. But that is a fool's errand, it never existed.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#Wisdom of the Ages_.E2.80.93_helm|Wisdom of the Ages]])</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#Tracking the Lost Knowledge_.E2.80.93_cloak|Tracking the Lost Knowledge]])</span><br/>
-<br/>
-=== Serendipity &ndash; limited ===
-<span style='color:#808080'><i>'Some inventions come out of nowhere.' - Kevla the Saviour</i></span><br/>
-<span style='color:orange'>New advancements: You never know what will be learned from here</span><br/>
-<br/>
-=== Shako &ndash; helm ===
-<span style='color:#808080'><i>Nobody would wear this helmet if it was not for its magic.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<br/>
-=== Shredder &ndash; knife ===
-<span style='color:#808080'><i>Doing gruesome things to your enemies will enhance their fear and make them weak.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
-<br/>
-=== Shroud of Iron &ndash; armour ===
-<span style='color:#808080'><i>Those armours are not very good, but if you wear more of them at the same time...</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 26%</span><br/>
-<span style='color:green'>Damage decreased by 1</span><br/>
-<span style='color:green'>1 fewer attacks</span><br/>
-<span style='color:#60A0FF'>2 fewer movement points</span><br/>
-<br/>
-=== Silver Axe &ndash; axe ===
-<span style='color:#808080'><i>Good metal is better than flashy magic.</i></span><br/>
-<span style='color:green'>Damage increased by 35%</span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<br/>
 === Sinister Lunacy &ndash; ring ===
 <span style='color:#808080'><i>If there was no lunatic causing the war, there would be no war.</i></span><br/>
-<span style='color:green'>Damage increased by 2 (melee attacks only)</span><br/>
 <span style='color:green'>New weapon special: charge (melee attacks only)</span><br/>
 <span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
 <br/>
-=== Slow Boots &ndash; boots ===
-<span style='color:#808080'><i>If you cannot outrun the knights, why do you even try?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+=== Sparkling Ring &ndash; ring ===
+<span style='color:#808080'><i>Nobody knows why the yellow-green gemstone in this ring is sparkling.</i></span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
 <br/>
-=== Slow Boots of Certainty &ndash; boots ===
-<span style='color:#808080'><i>I could have been here yesterday, but it was not worth the danger.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
+=== The Alliance &ndash; ring ===
+<span style='color:#808080'><i>We are The Alliance! We are one!</i></span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#alliance_.E2.80.93_leadership|alliance]]</span><br/>
+<br/>
+=== The Black Ring &ndash; ring ===
+<span style='color:#808080'><i>There were two hundreds of us before the battle. Three hundreds of us left the battlefield.</i></span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: plague (melee attacks only)</span><br/>
+<span style='color:green'>Increases all magical damages by 5%</span><br/>
+<br/>
+=== The gloomy Ring &ndash; ring ===
+<span style='color:#808080'><i>Bring sadness to your enemies by showing them how futile their effort is.</i></span><br/>
+<span style='color:green'>Damage increased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:purple'>New Ability: deathaura (requires [[#The gloomy Cloak_.E2.80.93_cloak|The gloomy Cloak]])</span><br/>
+<span style='color:purple'>New Ability: despair (requires [[#The gloomy Amulet_.E2.80.93_amulet|The gloomy Amulet]])</span><br/>
+<br/>
+=== The Unprecious Ring &ndash; ring ===
+<span style='color:#808080'><i>Sometimes a fiery or rimy blade is not what you need.</i></span><br/>
+<span style='color:green'>Sets damage type to blade</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#struggle_.E2.80.93_chance_to_hit|struggle]]</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
+<br/>
+=== The Warmth &ndash; ring ===
+<span style='color:#808080'><i>Solace from depressive gloom of northern winters when dusk follows dawn with nothing in between.</i></span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
+<span style='color:#60A0FF'>New ability: regenerates</span><br/>
+<br/>
+== sling ==
+=== Balls of Steel &ndash; sling ===
+<span style='color:#808080'><i>You will need courage in this cruel world.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
+<span style='color:#60A0FF'>16 more hitpoints per level</span><br/>
+<br/>
+== spear ==
+=== Caeordwyccywyrin's Spear &ndash; spear ===
+<span style='color:#808080'><i>Whose spear is this?</i></span><br/>
+<span style='color:green'>Damage increased by 4</span><br/>
+<span style='color:green'>40% more attacks</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Corpsegrinder &ndash; spear ===
+<span style='color:#808080'><i>Mutilating dead enemies makes you forget your woes.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#evisceration_.E2.80.93_dummy|evisceration]]</span><br/>
+<br/>
+=== Explosionlance &ndash; spear ===
+<span style='color:#808080'><i>Take that away, we need to stay silent.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>Damage increased by 1</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#extra damage (+5; impact)_.E2.80.93_dummy|extra damage (+5; impact)]]</span><br/>
+<br/>
+=== Hellrake &ndash; spear ===
+<span style='color:#808080'><i>Flowers bloom in hell too. And every flower has its gardener.</i></span><br/>
+<span style='color:green'>Damage increased by 60% (in EASY difficulty), 50% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Lightbringer's Trident &ndash; spear ===
+<span style='color:#808080'><i>He brought light, but it was red and searing.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:green'>50% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
+<br/>
+=== Odin's Spear &ndash; spear ===
+<span style='color:#808080'><i>Odin was a warrior, but every winter solstice, he came and brought gifts to kids.</i></span><br/>
+<span style='color:green'>Damage increased by 50%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to drain_.E2.80.93_dummy|immune to drain]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
+<br/>
+=== Return to the Tribe &ndash; spear ===
+<span style='color:#808080'><i>I may be no better, but at least I am different.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty) more attacks</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
 <br/>
 === Something &ndash; spear ===
 <span style='color:#808080'><i>Uhm... I wanted to say... ehm, that... it was... uh... basically... so now, I am saying that... uhm...</i></span><br/>
@@ -2063,106 +2808,92 @@ defeat your foes mace to face.</i></span><br/>
 <span style='color:green'>30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty) more attacks</span><br/>
 <span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
 <br/>
-=== Sorcery &ndash; craftable as any armour ===
-<span style='color:#808080'><i>'You shall never question my power!'
-'Only because of that cheap decorated armour of yours?'</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Opal and 2 Pearls</span><br/>
+=== The Humongously Enormous Megaspear &ndash; spear ===
+<span style='color:#808080'><i>Small weapons are for wimps.</i></span><br/>
+<span style='color:green'>40% (in EASY difficulty), 50% (in MEDIUM difficulty), 60% (in HARD difficulty) fewer attacks</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#hose_.E2.80.93_dummy|hose]]</span><br/>
 <br/>
-=== Soul Drinker &ndash; knife ===
-<span style='color:#808080'><i>The wounded assassin hid in the shadows. Only thrown knives could be seen. Then, he returned healthy.</i></span><br/>
-<span style='color:green'>Damage decreased by 20%</span><br/>
-<span style='color:green'>80% (in EASY difficulty), 65% (in MEDIUM difficulty), 50% (in HARD difficulty) more attacks</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
-<br/>
-=== Soul Eclipse &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Hide your soul and gifts of undeath await you.</i></span><br/>
-<span style='color:green'>Damage increased by 4 (in EASY difficulty), 0 (in MEDIUM difficulty), -4 (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: drain</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+=== The Impaler &ndash; spear ===
+<span style='color:#808080'><i>Do not hide behind your comrades, just run away.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#pierce_.E2.80.93_dummy|pierce]]</span><br/>
 <span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Unlife (immunity to poison, plague and drain)</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Obsidians, 2 Topazes, 3 Diamonds, 1 Emerald and 2 Amethysts</span><br/>
 <br/>
-=== Soul Hunter &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Noble cannibals do not eat corpses, they eat souls.</i></span><br/>
-<span style='color:green'>Damage increased by 40%</span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
+=== The Original Trident of Storms &ndash; spear ===
+<span style='color:#808080'><i>This is no obvious fake. Is it the true one or just a better fake?</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:green'>New attack: storm trident (14 - 4, fire)</span><br/>
+<br/>
+=== Wicked Spear of Cruelty &ndash; spear ===
+<span style='color:#808080'><i>With horror, he realised that the horse under him had joined the walking dead.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
+<span style='color:green'>New weapon special: plague</span><br/>
+<br/>
+== staff ==
+=== Absence of Purpose and Meaning &ndash; staff ===
+<span style='color:#808080'><i>Do not look for the meaning of this. There is none.</i></span><br/>
+<span style='color:green'>Damage increased by 4</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to pierce decreased by 20%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
+<span style='color:#60A0FF'>New ability: submerge</span><br/>
+<br/>
+=== Ashes of Dead Suns &ndash; staff ===
+<span style='color:#808080'><i>Things that destroy stars can destroy anything. According to one of a thousand hypotheses.</i></span><br/>
+<span style='color:#60A0FF'>15% chance to strike a devastating blow</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 25%</span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#murderlust_.E2.80.93_dummy|murderlust]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 3 Opals and 2 Pearls</span><br/>
 <br/>
-=== Soul Render &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Sticks and stones will break his bones, but this will destroy even his soul.</i></span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 55% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
+=== Cursed Memories &ndash; staff ===
+<span style='color:#808080'><i>Every hero suffers from horrors of the past. Only a few can have their enemies suffer from them instead.</i></span><br/>
+<span style='color:green'>Damage increased by 7 (in EASY difficulty), 6 (in MEDIUM difficulty), 5 (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
+<span style='color:green'>Increases all magical damages by 40% (in EASY difficulty), 35% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<br/>
+=== Dead End Road &ndash; staff ===
+<span style='color:#808080'><i>You will walk away from a necromancer fight. That does not imply that you will survive.</i></span><br/>
+<span style='color:green'>Damage increased by 25%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#greater infect_.E2.80.93_poison|greater infect]]</span><br/>
+<span style='color:green'>Increases all magical damages by 25%</span><br/>
+<br/>
+=== Lethal staff &ndash; staff ===
+<span style='color:#808080'><i>Most elvish shamans heal. Others kill.</i></span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 15%</span><br/>
 <span style='color:green'>Increases all magical damages by 30%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Topaz, 1 Pearl, 2 Rubies, 3 Emeralds, 1 Amethyst, 2 Sapphires and 1 Black Pearl</span><br/>
+<span style='color:purple'>10% more overall damage (requires [[#Lethal Axe_.E2.80.93_axe|Lethal Axe]])</span><br/>
 <br/>
-=== Soul Thrash &ndash; gauntlets ===
-<span style='color:#808080'><i>'My life is in ruins, if I die, I cannot lose anything.'
-Then he saw this item.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#soul thrash_.E2.80.93_damage|soul thrash]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#wrath_.E2.80.93_dummy|wrath]]</span><br/>
-<br/>
-=== Sparkling Ring &ndash; ring ===
-<span style='color:#808080'><i>Nobody knows why the yellow-green gemstone in this ring is sparkling.</i></span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<br/>
-=== Spectral Jet &ndash; knife ===
-<span style='color:#808080'><i>When you die, you should not expect your soul to go where you think it belongs.</i></span><br/>
-<span style='color:green'>Damage decreased by 20% (in EASY difficulty), 25% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Ghost)]]</span><br/>
-<br/>
-=== Spell Devourer &ndash; craftable as any armour ===
-<span style='color:#808080'><i>When the mighty wizard saw soldiers wearing armour protecting from his magic, he summoned undead to fight them.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
+=== Lethalia's Staff &ndash; staff ===
+<span style='color:#808080'><i>Tinebrithiel's will never be forgotten.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage increased by 3</span><br/>
+<span style='color:green'>Increases all magical damages by 30%</span><br/>
 <span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 3 Pearls, 3 Diamonds and 2 Rubies</span><br/>
+<span style='color:purple'>1 more movement point (requires [[#Lethalia's Armour_.E2.80.93_armour|Lethalia's Armour]])</span><br/>
 <br/>
-=== Spineripper &ndash; knife ===
-<span style='color:#808080'><i>Look at that exposed back.</i></span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:green'>New weapon special: backstab</span><br/>
-<br/>
-=== Spirits of a Madman's Alacrity &ndash; potion ===
-<span style='color:#808080'><i>Are you sane? You cannot fight so much, we will run out of enemies too soon!</i></span><br/>
-<span style='color:orange'>1 extra attack per turn</span><br/>
-<br/>
-=== Spiritual Presence &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Run through hills, swamps and sand as if you had no body limiting you.</i></span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on frozen lands set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on flat terrains set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through dark caves set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through mushroom groves set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through villages set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs through castles set to 1</span><br/>
+=== Mother de Rais &ndash; staff ===
+<span style='color:#808080'><i>The undead were too numerous to be burned by her fireballs. She had to jump into a river far below to save herself.</i></span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Movement costs in shallow waters set to 1</span><br/>
 <span style='color:#60A0FF'>Movement costs on coastal reefs set to 1</span><br/>
 <span style='color:#60A0FF'>Movement costs through swampy places set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs on hills set to 1</span><br/>
-<span style='color:#60A0FF'>Movement costs across sands set to 1</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Opal, 1 Diamond, 3 Emeralds, 2 Amethysts and 1 Sapphire</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Showshaunshog's Staff &ndash; staff ===
+<span style='color:#808080'><i>Anaximandros said that all comes from water.
+Showshaunshog proved him wrong by collecting condensed water from smoke.</i></span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 25%</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15% (in EASY difficulty)</span><br/>
 <br/>
 === Staff of Aimucasur &ndash; staff ===
 <span style='color:#808080'><i>A skeletal horde rose from the mud to take lives away. Konrad's warriors were too strong for them.</i></span><br/>
@@ -2185,6 +2916,12 @@ Then he saw this item.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
 <span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
 <br/>
+=== Staff of Crelanu &ndash; staff ===
+<span style='color:#808080'><i>Crelanu's staff fell into the wrong hands before it was even made.</i></span><br/>
+<span style='color:green'>Increases all magical damages by 40%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<br/>
 === Staff of Kerathur &ndash; staff ===
 <span style='color:#808080'><i>'I know that you have no idea who I am...' - Kerathur the Unheard Of</i></span><br/>
 <span style='color:green'>Damage increased by 2</span><br/>
@@ -2194,17 +2931,11 @@ Then he saw this item.</i></span><br/>
 <br/>
 === Staff of Koschei &ndash; staff ===
 <span style='color:#808080'><i>Koschei kidnapped a young princess. His mundane motivations caused his fall.</i></span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Spells suck 2 health from targets with each hit</span><br/>
 <span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
 <span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 35%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
 <span style='color:purple'>16 to Maximum Health (requires [[#Koschei's Journal_.E2.80.93_limited|Koschei's Journal]])</span><br/>
-<br/>
-=== Starbreaker &ndash; xbow ===
-<span style='color:#808080'><i>So you are good at blocking? We shall see about that!</i></span><br/>
-<span style='color:green'>Damage increased by 8 (in EASY difficulty), 5 (in MEDIUM difficulty), 2 (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#trickery_.E2.80.93_dummy|trickery]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (15)]]</span><br/>
 <br/>
 === Stardust &ndash; staff ===
 <span style='color:#808080'><i>Born from absolute destruction, craving for absolute destruction.</i></span><br/>
@@ -2221,47 +2952,184 @@ Then he saw this item.</i></span><br/>
 <span style='color:green'>Increases all magical damages by 30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
 <span style='color:green'>New attack: lightning (18 - 2, lightning)</span><br/>
 <br/>
-=== Static Float &ndash; helm ===
-<span style='color:#808080'><i>This one will be destroyed only at the end of times.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: submerge</span><br/>
+=== Tears of Void &ndash; staff ===
+<span style='color:#808080'><i>Who made up this name? What was he thinking?</i></span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Increases all magical damages by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 15%</span><br/>
 <br/>
-=== Steel Helmet &ndash; helm ===
-<span style='color:#808080'><i>'What is this thing good for?'
-'Nothing special.'</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+=== The Killer of Great Magi &ndash; staff ===
+<span style='color:#808080'><i>I care not how much better you are. Your crippling overspecialisation will be your downfall.</i></span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 40%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
-=== Steps to Perdition &ndash; boots ===
-<span style='color:#808080'><i>I agree that you are effective, but it still leads to disaster - one accident and you are dead.</i></span><br/>
-<span style='color:#60A0FF'>Decreases physical resistances by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
-<span style='color:green'>Damage increased by 20% (in EASY difficulty), 15% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
-<span style='color:green'>Enemy resistances to blade decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to impact decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<br/>
-=== Stolen Potion &ndash; potion ===
-<span style='color:#808080'><i>I have stolen this. Now all the word is here for me to steal.</i></span><br/>
-<span style='color:#60A0FF'>New ability: skirmisher</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#steals_.E2.80.93_dummy|steals]]</span><br/>
-<br/>
-=== Stormforce &ndash; bow ===
-<span style='color:#808080'><i>Is that the fabled Stormforce? I thought it was just a legend!</i></span><br/>
-<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
-<br/>
-=== Stormgrip &ndash; gauntlets ===
-<span style='color:#808080'><i>You are an evil overlord, armoured and shielded against everything? I will slay you anyway.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
+=== Townsend Dark Discharge &ndash; staff ===
+<span style='color:#808080'><i>The right tool for a self-sustaining wizard.</i></span><br/>
+<span style='color:green'>Damage increased by 3</span><br/>
 <span style='color:green'>Sets damage type to lightning</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: charge</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
+<br/>
+=== Violent Mage's Staff &ndash; staff ===
+<span style='color:#808080'><i>He was not a bad mage, but he enjoyed hitting enemies with hard objects a bit too much.</i></span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
+<span style='color:purple'>New ability: firecast (requires the two other Violent Mage's items)</span><br/>
+<br/>
+=== Virtue of Hope &ndash; staff ===
+<span style='color:#808080'><i>See the ones who know.</i></span><br/>
+<span style='color:green'>Increases all magical damages by 25%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>4 more hitpoints per level per level</span><br/>
+<br/>
+== sword ==
+=== Aevyn's Wrath &ndash; sword ===
+<span style='color:#808080'><i>I cannot quite figure out how to use this thing.</i></span><br/>
+<span style='color:green'>Damage decreased by 20% (in EASY difficulty), 30% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (10)]]</span><br/>
+<br/>
+=== Avenging Fire &ndash; sword ===
+<span style='color:#808080'><i>Burn! Let the hair catch fire and help the skin burn. Ignite the skin and help the flesh burn.</i></span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#flaming radiance_.E2.80.93_dummy|flaming radiance]]</span><br/>
+<br/>
+=== Blade of Turisas &ndash; sword ===
+<span style='color:#808080'><i>Every nation had its god of war. Or was it just one with many names?</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
+<br/>
+=== Brightslash &ndash; sword ===
+<span style='color:#808080'><i>He came like a shining star,
+allied with the sun,
+he smote the villains,
+and saved the righteous.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (2)_.E2.80.93_dummy|absorbs (2)]]</span><br/>
+<span style='color:#60A0FF'>New ability: cures</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#regenerates (VALUE)_.E2.80.93_regenerate|regenerates (16)]]</span><br/>
+<br/>
+=== Claymore &ndash; sword ===
+<span style='color:#808080'><i>I am done with you, go away!</i></span><br/>
+<span style='color:green'>Damage increased by 10%</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#knockback_.E2.80.93_damage|knockback]]</span><br/>
+<br/>
+=== Colossally Colossal Arch-Devilish Blade of Universal Annihilation &ndash; sword ===
+<span style='color:#808080'><i>Forged by the Paladin of Golden Glory with the Hammer of Eternal Magic.</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>Enemy resistances to blade decreased by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: aura of power</span><br/>
+<br/>
+=== Cunctator's sword &ndash; sword ===
+<span style='color:#808080'><i>Nobody wanted to face Cunctator. He never fought when you wanted to fight him.</i></span><br/>
+<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
+<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#explosive slow_.E2.80.93_damage|explosive slow]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#hit and run_.E2.80.93_dummy|hit and run]]</span><br/>
+<span style='color:purple'>New melee weapon special: struggle (requires [[#Cunctator's Armour_.E2.80.93_armour|Cunctator's Armour]])</span><br/>
+<span style='color:purple'>5% to all magical resistances (requires [[#Cunctator's Helmet_.E2.80.93_helm|Cunctator's Helmet]])</span><br/>
+<br/>
+=== Dark Sword of Destruction &ndash; sword ===
+<span style='color:#808080'><i>Real warriors know that their opponents will get heavy armours and prepare for it.</i></span><br/>
+<span style='color:green'>Damage increased by 50%</span><br/>
+<span style='color:green'>Sets damage type to cold</span><br/>
 <span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Dark Helm of Destruction_.E2.80.93_helm|Dark Helm of Destruction]])</span><br/>
+<span style='color:purple'>+1 to base attacks (requires [[#Dark Gloves of Destruction_.E2.80.93_gauntlets|Dark Gloves of Destruction]])</span><br/>
+<br/>
+=== Deathwhirl &ndash; sword ===
+<span style='color:#808080'><i>Swarm him so that he would not get to me! Oh, dammit...</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>Chance to get hit decreased by 5%</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 5%</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#penetrates_.E2.80.93_dummy|penetrates]]</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
+<br/>
+=== Doombringer &ndash; sword ===
+<span style='color:#808080'><i>Hitting the enemy hard is not crucial. You have to make sure that you will not get killed when he hits you.</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#disintegrate_.E2.80.93_damage|disintegrate]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<br/>
+=== Doombringer &ndash; sword ===
+<span style='color:#808080'><i>Hitting the enemy hard is not crucial. You have to make sure that you will not get killed when he hits you.</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 50% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>20% more attacks</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: slow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#disintegrate_.E2.80.93_damage|disintegrate]]</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<br/>
+=== Dragon Claw &ndash; sword ===
+<span style='color:#808080'><i>Claws of dragons have no unusual magical properties, but they cut so well.</i></span><br/>
+<span style='color:green'>Damage increased by 30%</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>30% more attacks</span><br/>
+<br/>
+=== Eidolon's Sword &ndash; sword ===
+<span style='color:#808080'><i>He could fuel his champion alone, as his powers of light and darkness amplified each other. He became an Eidolon.</i></span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#unholybane_.E2.80.93_damage|unholybane]]</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
+<span style='color:purple'>4% to cold resistance (requires [[#Eidolon's Ring_.E2.80.93_ring|Eidolon's Ring]])</span><br/>
+<span style='color:purple'>3% to pierce resistance (requires [[#Eidolon's Necklace_.E2.80.93_amulet|Eidolon's Necklace]])</span><br/>
+<span style='color:purple'>3% to blade resistance (requires [[#Eidolon's Armour_.E2.80.93_armour|Eidolon's Armour]])</span><br/>
+<span style='color:purple'>4 to hitpoints (requires [[#Eidolon's Mask_.E2.80.93_helm|Eidolon's Mask]])</span><br/>
+<span style='color:purple'>1 to damage (requires [[#Eidolon's Gauntlets_.E2.80.93_gauntlets|Eidolon's Gauntlets]])</span><br/>
+<span style='color:purple'>1 to movement (requires [[#Eidolon's Boots_.E2.80.93_boots|Eidolon's Boots]])</span><br/>
+<span style='color:purple'>2% to arcane resistance (requires [[#Eidolon's Coat_.E2.80.93_cloak|Eidolon's Coat]])</span><br/>
+<br/>
+=== Flaming Sword &ndash; sword ===
+<span style='color:#808080'><i>If you need to fight ghosts, good steel is not enough.</i></span><br/>
+<span style='color:green'>Damage increased by 7</span><br/>
+<span style='color:green'>Sets damage type to fire</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
+<br/>
+=== Holy Sword &ndash; sword ===
+<span style='color:#808080'><i>You, comrade with that Unholy Axe, position yourself as far from me as possible!</i></span><br/>
+<span style='color:green'>Damage increased by 25%</span><br/>
+<span style='color:green'>Sets damage type to arcane</span><br/>
+<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
+<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
+<span style='color:#60A0FF'>New ability: illuminates</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unholybane (INTENSITY)_.E2.80.93_heals|unholybane (12)]]</span><br/>
+<span style='color:#60A0FF'>Sets alignment to lawful</span><br/>
+<br/>
+=== Lilith's Other Old Precious &ndash; sword ===
+<span style='color:#808080'><i>In order to be able to fight with any weapon available, Lilith swaps weapon types once per century.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#absorbs (1)_.E2.80.93_dummy|absorbs (1)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#regenerates (VALUE)_.E2.80.93_regenerate|regenerates (16)]]</span><br/>
+<br/>
+=== Pyromancer's Sword &ndash; sword ===
+<span style='color:#808080'><i>Flames were his nature, they replaced his insides.</i></span><br/>
+<span style='color:green'>Damage increased by 20% (in EASY difficulty), -10% (in MEDIUM difficulty), -40% (in HARD difficulty)</span><br/>
+<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:purple'>New ability: firecast (requires [[#Pyromancer's Ring_.E2.80.93_ring|Pyromancer's Ring]])</span><br/>
+<span style='color:purple'>5% to magical resistances (requires [[#Pyromancer's Cloak_.E2.80.93_cloak|Pyromancer's Cloak]])</span><br/>
+<br/>
+=== Rherraent's Sword &ndash; sword ===
+<span style='color:#808080'><i>In his hands, the sword was a formidable weapon. In the hands of its thief, it was useless.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:purple'>+2 to base melee damage (requires [[#Rherraent's Armour_.E2.80.93_armour|Rherraent's Armour]])</span><br/>
+<span style='color:purple'>+2 to base melee damage (requires [[#Rherraent's Helm_.E2.80.93_helm|Rherraent's Helm]])</span><br/>
+<span style='color:purple'>+2 to base melee damage (requires [[#Rherraent's Ring_.E2.80.93_ring|Rherraent's Ring]])</span><br/>
 <br/>
 === Stormrend &ndash; sword ===
 <span style='color:#808080'><i>They are protected well. Have them try to survive lightning.</i></span><br/>
@@ -2269,87 +3137,18 @@ Then he saw this item.</i></span><br/>
 <span style='color:green'>Sets damage type to lightning</span><br/>
 <span style='color:green'>New weapon special: [[LotI_Abilities#trickery_.E2.80.93_dummy|trickery]]</span><br/>
 <br/>
-=== Straight out of Nowhere &ndash; dagger ===
-<span style='color:#808080'><i>Expect the unexpected. Diabolus ex machina.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>Merges attacks</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<br/>
-=== Strength &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Why does nobody want to play handwrestling with me?</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage increased by 10% (melee attacks only)</span><br/>
-<span style='color:green'>Damage increased by 2 (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 3 Topazes and 2 Opals</span><br/>
-<br/>
 === Sword of Barys &ndash; sword ===
 <span style='color:#808080'><i>A rare metal burns with green flame. Its ashes are poisonous, so be careful with it.</i></span><br/>
 <span style='color:green'>Damage increased by 20%</span><br/>
 <span style='color:green'>Sets damage type to fire</span><br/>
 <span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
+<span style='color:green'>Increases all magical damages by 20%</span><br/>
 <br/>
 === Sword of Krux &ndash; sword ===
 <span style='color:#808080'><i>Krux has never been a great warrior, deceptive diplomacy was his favourite weapon.</i></span><br/>
 <span style='color:green'>Damage increased by 3</span><br/>
 <span style='color:green'>Increases all magical damages by 20%</span><br/>
 <span style='color:#60A0FF'>Resistance to blade increased by 15%</span><br/>
-<br/>
-=== Taxes &ndash; boots ===
-<span style='color:#808080'><i>What is harder to escape than death? Taxes.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:#60A0FF'>3 more movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#tax collector_.E2.80.93_dummy|tax collector]]</span><br/>
-<br/>
-=== Tears of the Dead &ndash; amulet ===
-<span style='color:#808080'><i>Pity the walking dead for they know no pleasure.</i></span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#immune to drain_.E2.80.93_dummy|immune to drain]]</span><br/>
-<br/>
-=== The Alliance &ndash; ring ===
-<span style='color:#808080'><i>We are The Alliance! We are one!</i></span><br/>
-<span style='color:green'>Damage increased by 1</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#alliance_.E2.80.93_leadership|alliance]]</span><br/>
-<br/>
-=== The Art of War &ndash; craftable as any armour ===
-<span style='color:#808080'><i>If you know the enemy and you know yourself, you need not fear the outcome of a thousand battles.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (25)]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 2 Topazes, 1 Opal, 1 Pearl, 3 Emeralds and 3 Sapphires</span><br/>
-<br/>
-=== The Black Ring &ndash; ring ===
-<span style='color:#808080'><i>There were two hundreds of us before the battle. Three hundreds of us left the battlefield.</i></span><br/>
-<span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: plague (melee attacks only)</span><br/>
-<span style='color:green'>Increases all magical damages by 5%</span><br/>
-<br/>
-=== The Cannon &ndash; xbow ===
-<span style='color:#808080'><i>If I will ever get to you, you will be wrecked!</i></span><br/>
-<span style='color:green'>Damage increased by 55% (in EASY difficulty), 45% (in MEDIUM difficulty), 35% (in HARD difficulty)</span><br/>
-<span style='color:green'>30% more attacks</span><br/>
-<span style='color:#60A0FF'>2 fewer movement points</span><br/>
-<br/>
-=== The Crusher &ndash; knife ===
-<span style='color:#808080'><i>I will send my assassins to slay the lich. You will gear them properly.</i></span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 45% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>Sets damage type to impact</span><br/>
-<br/>
-=== The Cure &ndash; mace ===
-<span style='color:#808080'><i>You are the disease. We are the cure.</i></span><br/>
-<span style='color:green'>Damage increased by 6 (in EASY difficulty), 5 (in MEDIUM difficulty), 4 (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (25)]]</span><br/>
-<br/>
-=== The Deadborn &ndash; cloak ===
-<span style='color:#808080'><i>Darkest legends tell of necromancers creating undead so pure that they were never tainted by life, dead from birth.</i></span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
 <br/>
 === The Decimator &ndash; sword ===
 <span style='color:#808080'><i>Do not get too crazy with that sword.</i></span><br/>
@@ -2361,116 +3160,15 @@ Then he saw this item.</i></span><br/>
 <span style='color:#60A0FF'>Resistance to impact decreased by 15%</span><br/>
 <span style='color:#60A0FF'>Resistance to pierce decreased by 15%</span><br/>
 <br/>
-=== The Doctrine of Vindictiveness &ndash; limited ===
-<span style='color:#808080'><i>If they attack you, make sure they will not dare or will not exist to attack again.</i></span><br/>
-<span style='color:orange'>New advancements: A distinctively vindictive view on combat</span><br/>
-<br/>
-=== The End of All that Is &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>From the victim's point of view, there was no death at all.</i></span><br/>
-<span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#soul annihilation_.E2.80.93_damage|soul annihilation]]</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 1 Opal, 1 Pearl, 3 Diamonds, 1 Ruby, 2 Emeralds and 1 Amethyst</span><br/>
-<br/>
-=== The Essence of Magic &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Fire, earth, air and water. And then there is magic.</i></span><br/>
+=== The Decimator &ndash; sword ===
+<span style='color:#808080'><i>Do not get too crazy with that sword.</i></span><br/>
 <span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>Sets damage type to arcane</span><br/>
-<span style='color:green'>Increases all magical damages by 35%</span><br/>
-<span style='color:purple'>5% to all resistances to magic (requires [[#Quintessence_.E2.80.93_craftable as any armour|Quintessence]])</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Pearl, 1 Diamond and 1 Ruby</span><br/>
-<br/>
-=== The Fencer's Study &ndash; limited ===
-<span style='color:#808080'><i>Do you think fencing takes a lot of time to learn? Just buy this for 20 gold and see how easy it is!</i></span><br/>
-<span style='color:orange'>New advancements: Quick mastery of fencing</span><br/>
-<br/>
-=== The Generous Armour &ndash; armour ===
-<span style='color:#808080'><i>Hey there, you are a bad fighter, wear this.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#producer_.E2.80.93_dummy|producer]]</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== The gloomy Amulet &ndash; amulet ===
-<span style='color:#808080'><i>Bring sadness to your enemies by showing them how weak they are.</i></span><br/>
-<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#The gloomy Cloak_.E2.80.93_cloak|The gloomy Cloak]])</span><br/>
-<span style='color:purple'>+1 base damage (requires [[#The gloomy Ring_.E2.80.93_ring|The gloomy Ring]])</span><br/>
-<br/>
-=== The gloomy Cloak &ndash; cloak ===
-<span style='color:#808080'><i>Bring sadness to your enemies by showing them how slow they are.</i></span><br/>
-<span style='color:green'>Damage increased by 40%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#The gloomy Ring_.E2.80.93_ring|The gloomy Ring]])</span><br/>
-<span style='color:purple'>1 more movement point (requires [[#The gloomy Amulet_.E2.80.93_amulet|The gloomy Amulet]])</span><br/>
-<br/>
-=== The gloomy Ring &ndash; ring ===
-<span style='color:#808080'><i>Bring sadness to your enemies by showing them how futile their effort is.</i></span><br/>
-<span style='color:green'>Damage increased by 10%</span><br/>
+<span style='color:green'>New weapon special: charge</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#anger_.E2.80.93_attacks|anger]]</span><br/>
 <span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:purple'>New Ability: deathaura (requires [[#The gloomy Cloak_.E2.80.93_cloak|The gloomy Cloak]])</span><br/>
-<span style='color:purple'>New Ability: despair (requires [[#The gloomy Amulet_.E2.80.93_amulet|The gloomy Amulet]])</span><br/>
-<br/>
-=== The Godless &ndash; craftable as any armour ===
-<span style='color:#808080'><i>Do not justify your actions with the name of a man made deity.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 30%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Obsidian, 1 Topaz, 1 Opal, 1 Pearl, 1 Diamond, 1 Ruby and 1 Emerald</span><br/>
-<br/>
-=== The Great Truth &ndash; mace ===
-<span style='color:#808080'><i>The Great Truth is that there is no Great Truth.</i></span><br/>
-<span style='color:green'>Damage increased by 14 (in EASY difficulty), 12 (in MEDIUM difficulty), 10 (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<br/>
-=== The Grey Cloak &ndash; cloak ===
-<span style='color:#808080'><i>It somewhat reminds me of Gundolf the Great.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage increased by 10%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to blade decreased by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== The Grim Butcher &ndash; axe ===
-<span style='color:#808080'><i>Pigs, goats, men... is there a difference? They all taste the same.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 35% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#evisceration_.E2.80.93_dummy|evisceration]]</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<br/>
-=== The Humongously Enormous Megaspear &ndash; spear ===
-<span style='color:#808080'><i>Small weapons are for wimps.</i></span><br/>
-<span style='color:green'>40% (in EASY difficulty), 50% (in MEDIUM difficulty), 60% (in HARD difficulty) fewer attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#hose_.E2.80.93_dummy|hose]]</span><br/>
-<br/>
-=== The Impaler &ndash; spear ===
-<span style='color:#808080'><i>Do not hide behind your comrades, just run away.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#pierce_.E2.80.93_dummy|pierce]]</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
-<br/>
-=== The Infidel &ndash; limited ===
-<span style='color:#808080'><i>Fidel is dead. Hail the Infidel.</i></span><br/>
-<span style='color:#60A0FF'>Sets alignment to neutral</span><br/>
-<br/>
-=== The Jester &ndash; helm ===
-<span style='color:#808080'><i>We needed better entertainment. There're in flames now.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 2%</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<br/>
-=== The Killer of Great Magi &ndash; staff ===
-<span style='color:#808080'><i>I care not how much better you are. Your crippling overspecialisation will be your downfall.</i></span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 40%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
+<span style='color:#60A0FF'>Resistance to blade decreased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to impact decreased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce decreased by 15%</span><br/>
 <br/>
 === The Nightreaver &ndash; sword ===
 <span style='color:#808080'><i>Aggressive and violent, they strike when least expected and take away all serenity.</i></span><br/>
@@ -2478,131 +3176,20 @@ Then he saw this item.</i></span><br/>
 <span style='color:green'>Enemy resistances to blade decreased by 10%</span><br/>
 <span style='color:green'>New weapon special: [[LotI_Abilities#chaotic_.E2.80.93_damage|chaotic]]</span><br/>
 <br/>
-=== The Noble Survivor &ndash; armour ===
-<span style='color:#808080'><i>He wishes that all the nobility could be hung with the guts of priests. That will not work on me.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 35%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leeches_.E2.80.93_dummy|leech]]</span><br/>
-<span style='color:#60A0FF'>New ability: submerge</span><br/>
+=== The Outsider Sword &ndash; sword ===
+<span style='color:#808080'><i>Mages say it does not come from any world.</i></span><br/>
+<span style='color:green'>Damage increased by 65% (in EASY difficulty), 50% (in MEDIUM difficulty), 35% (in HARD difficulty)</span><br/>
+<span style='color:green'>25% (in EASY difficulty), 15% (in MEDIUM difficulty), 5% (in HARD difficulty) more attacks</span><br/>
+<span style='color:purple'>2 to base melee damage (requires [[#Transformed Flesh_.E2.80.93_cloak|Transformed Flesh]])</span><br/>
+<span style='color:purple'>2 to base melee damage (requires [[#Bones of Steel_.E2.80.93_boots|Bones of Steel]])</span><br/>
+<span style='color:purple'>2 to base melee damage (requires [[#Hydraulic Core_.E2.80.93_amulet|Hydraulic Core]])</span><br/>
+<span style='color:purple'>1 to base melee attacks (requires [[#Mind Assisting Element_.E2.80.93_helm|Mind Assisting Element]])</span><br/>
 <br/>
-=== The Original Trident of Storms &ndash; spear ===
-<span style='color:#808080'><i>This is no obvious fake. Is it the true one or just a better fake?</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>Sets damage type to fire</span><br/>
-<span style='color:green'>New weapon special: slow</span><br/>
-<span style='color:green'>New attack: storm trident (14 - 4, fire)</span><br/>
-<br/>
-=== The Outcast &ndash; bow ===
-<span style='color:#808080'><i>Loneliness will teach you to stop relying on others. It makes you free if you pay its price.</i></span><br/>
-<span style='color:green'>Damage increased by 10%</span><br/>
-<span style='color:green'>20% more attacks</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<br/>
-=== The Parasite &ndash; armour ===
-<span style='color:#808080'><i>They make promises of the impossible.
-They say they guide you to reach the impossible.
-They pretend you had reached the impossible.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>2 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#parasite_.E2.80.93_dummy|parasite]]</span><br/>
-<br/>
-=== The Predator &ndash; bow ===
-<span style='color:#808080'><i>Try not to split from the group.</i></span><br/>
-<span style='color:green'>Damage increased by 30% (in EASY difficulty), 20% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#lurk_.E2.80.93_damage|lurk]]</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 15%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
-<br/>
-=== The Ragtag Misfit &ndash; cloak ===
-<span style='color:#808080'><i>All I want is your love... Yes, I know I will get no love, but I will get your gold at least.</i></span><br/>
-<span style='color:green'>Damage increased by 2</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#steals_.E2.80.93_dummy|steals]]</span><br/>
-<br/>
-=== The Shiverbringer &ndash; craftable as any armour ===
-<span style='color:#808080'><i>His presence brought shivers of fear to everyone who defied him. He was defeated by the insane.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 20%</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 15%</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (20)]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal, 2 Diamonds, 2 Rubies, 1 Emerald and 1 Amethyst</span><br/>
-<br/>
-=== The Sick Face &ndash; helm ===
-<span style='color:#808080'><i>He looks sick. Killing him will be easy, just try not to catch whatever he has.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>New weapon special: poison (melee attacks only)</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#radiation_.E2.80.93_dummy|radiation]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
-<span style='color:#60A0FF'>16 fewer hitpoints per level</span><br/>
-<br/>
-=== The Touch of Death &ndash; gauntlets ===
-<span style='color:#808080'><i>There is no touch of death. But you can take your time to aim at the windpipe from the correct angle...</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Damage increased by 20 (in EASY difficulty), 18 (in MEDIUM difficulty), 16 (in HARD difficulty)</span><br/>
-<span style='color:green'>4 fewer attacks</span><br/>
-<br/>
-=== The Touch of God &ndash; cloak ===
-<span style='color:#808080'><i>'I... I have been touched by god.'
-'Touched by our almightly lord and saviour?'
-'No, by lord Cthulhu.'</i></span><br/>
-<span style='color:#60A0FF'>Decreases physical resistances by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (40)]]</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== The Unprecious Ring &ndash; ring ===
-<span style='color:#808080'><i>Sometimes a fiery or rimy blade is not what you need.</i></span><br/>
-<span style='color:green'>Sets damage type to blade</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#struggle_.E2.80.93_chance_to_hit|struggle]]</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
-<br/>
-=== The Unraveller &ndash; armour ===
-<span style='color:#808080'><i>A mummy cannot be stopped. If it is tangled, it will just unravel the tangled parts.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>3 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#resistant to slow_.E2.80.93_dummy|resistant to slow]]</span><br/>
-<br/>
-=== The Unrepenting &ndash; bow ===
-<span style='color:#808080'><i>I have broken the sacred vow, forgotten the pledge of allegiance, lost my faith.
-I did what I did. I cannot change it, so why should I torment myself with it?</i></span><br/>
-<span style='color:green'>Damage increased by 5 (in EASY difficulty), 4 (in MEDIUM difficulty), 3 (in HARD difficulty)</span><br/>
-<span style='color:green'>40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty) more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#distant attack_.E2.80.93_attacks|distant attack]]</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#hit and run_.E2.80.93_dummy|hit and run]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#anathema_.E2.80.93_leadership|anathema]]</span><br/>
-<br/>
-=== The Unstoppable &ndash; mace ===
-<span style='color:#808080'><i>No one can bargain with him. There is no way to reason with him. He feels no fear. There is nothing at all that would stop him... until the evil is banished.</i></span><br/>
-<span style='color:green'>New weapon special: marksman</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#resistant to slow_.E2.80.93_dummy|resistant to slow]]</span><br/>
-<br/>
-=== The Vile Knife &ndash; knife ===
-<span style='color:#808080'><i>Wounds heal, poison remains.</i></span><br/>
-<span style='color:green'>Damage increased by 25% (in EASY difficulty), 15% (in MEDIUM difficulty), 5% (in HARD difficulty)</span><br/>
-<span style='color:green'>40% more attacks</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:green'>New weapon special: poison</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#greater backstab_.E2.80.93_damage|greater backstab]]</span><br/>
-<br/>
-=== The Warmth &ndash; ring ===
-<span style='color:#808080'><i>Solace from depressive gloom of northern winters when dusk follows dawn with nothing in between.</i></span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 30%</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<br/>
-=== Theophrastus Redivivus &ndash; limited ===
-<span style='color:#808080'><i>Difficile est negave Deos, si inconcione quaratur, sed in familliarium, sermone, en consessur facilitimum...</i></span><br/>
-<span style='color:purple'>10% to arcane resistance (requires [[#Treatise of the Three Impostors_.E2.80.93_limited|Treatise of the Three Impostors]])</span><br/>
-<span style='color:purple'>New ability: regenerates slightly (requires [[#Al-Fuṣūl wa al-ghāyāt_.E2.80.93_limited|Al-Fuṣūl wa al-ghāyāt]])</span><br/>
+=== The Searing Ice &ndash; sword ===
+<span style='color:#808080'><i>Be careful not to get some cold burns.</i></span><br/>
+<span style='color:#60A0FF'>Sucks 2 health from targets with each hit</span><br/>
+<span style='color:#60A0FF'>Resistance to fire increased by 15%</span><br/>
+<span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
 <br/>
 === Thornsword &ndash; sword ===
 <span style='color:#808080'><i>'How can you cut something with that?'
@@ -2613,237 +3200,12 @@ I did what I did. I cannot change it, so why should I torment myself with it?</i
 <span style='color:#60A0FF'>Chance to get hit decreased by 10%</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#thorns_.E2.80.93_dummy|thorns]]</span><br/>
 <br/>
-=== Thundering Revenge &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>I call this new weapon of mine.. bazooka!</i></span><br/>
-<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
-<span style='color:green'>Sets damage type to lightning</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#explosive_.E2.80.93_damage|explosive]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#retribution_.E2.80.93_dummy|retribution]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Pearl, 2 Rubies, 3 Emeralds and 1 Sapphire</span><br/>
-<br/>
-=== Titan's Bane &ndash; dagger ===
-<span style='color:#808080'><i>My blows may cause mere scratches on your skin, but it can be enough for you to die.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:green'>Sets damage type to arcane</span><br/>
-<span style='color:#60A0FF'>20% chance to strike a devastating blow</span><br/>
-<br/>
-=== Tome of Bards &ndash; limited ===
-<span style='color:#808080'><i>Stand up and fight
-Stand up and see the sky turn bright</i></span><br/>
-<span style='color:orange'>New advancements: Techniques of inspiring allies to deal more damage</span><br/>
-<br/>
-=== Tome of Bards, Volume II &ndash; limited ===
-<span style='color:#808080'><i>Shining and so glorious
-The bloodline of true warriors</i></span><br/>
-<span style='color:orange'>New advancements: Techniques of inspiring allies to fight better and annoying enemies</span><br/>
-<br/>
-=== Tome of Liches &ndash; limited ===
-<span style='color:#808080'><i>Are you fed up of mortality?</i></span><br/>
-<span style='color:orange'>New advancements: Teachings of the dark arts of necromancy</span><br/>
-<br/>
-=== Topaz &ndash; gem ===
-<span style='color:#808080'><i>Although this gem looks interesting in appearance, its magical power is not really remarkable, but its importance for magical gem combination is not neglectful.</i></span><br/>
-<br/>
-=== Tormentor of Light &ndash; mace ===
-<span style='color:#808080'><i>In the absence of light, darkness and disorder rules.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>25% more attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic_.E2.80.93_damage|chaotic]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens_.E2.80.93_illuminates|darkens]]</span><br/>
-<br/>
-=== Townsend Dark Discharge &ndash; staff ===
-<span style='color:#808080'><i>The right tool for a self-sustaining wizard.</i></span><br/>
-<span style='color:green'>Damage increased by 3</span><br/>
-<span style='color:green'>Sets damage type to lightning</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: charge</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<br/>
-=== Traces of Blood &ndash; dagger ===
-<span style='color:#808080'><i>That assassin is hard to find, but his bloody trace can be followed. Shame that it costs so many lives.</i></span><br/>
-<span style='color:green'>Damage increased by 60% (in EASY difficulty), 50% (in MEDIUM difficulty), 40% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
-<br/>
-=== Tracking the Lost Knowledge &ndash; cloak ===
-<span style='color:#808080'><i>If it has been lost, then it must had been created before. Maybe it was never created.</i></span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Spells suck 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:purple'>New ability: absorb (1) (requires [[#Wisdom of the Ages_.E2.80.93_helm|Wisdom of the Ages]])</span><br/>
-<span style='color:purple'>New base ranged weapon special: horrid (requires [[#Search for Wisdom_.E2.80.93_boots|Search for Wisdom]])</span><br/>
-<br/>
-=== Treatise of the Three Impostors &ndash; limited ===
-<span style='color:#808080'><i>However important it may be for all men to know the Truth, very few, nevertheless, are acquainted with it...</i></span><br/>
-<span style='color:purple'>10% to arcane resistance (requires [[#Theophrastus Redivivus_.E2.80.93_limited|Theophrastus Redivivus]])</span><br/>
-<span style='color:purple'>New ability: exile (requires [[#Al-Fuṣūl wa al-ghāyāt_.E2.80.93_limited|Al-Fuṣūl wa al-ghāyāt]])</span><br/>
-<br/>
 === Twinkling Sword &ndash; sword ===
 <span style='color:#808080'><i>Run towards your enemy and attack sooner than he expects.</i></span><br/>
 <span style='color:green'>Damage increased by 20%</span><br/>
 <span style='color:green'>Sets damage type to cold</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 15%</span><br/>
 <span style='color:#60A0FF'>2 more movement points</span><br/>
-<br/>
-=== Unholy Axe &ndash; axe ===
-<span style='color:#808080'><i>Use the lightbeam spell. It kills anything unholy enough.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#darkens_.E2.80.93_illuminates|darkens]]</span><br/>
-<span style='color:#60A0FF'>Sets alignment to chaotic</span><br/>
-<br/>
-=== Unimpalability &ndash; craftable as any armour ===
-<span style='color:#808080'><i>The executioner tried to impale him on a stick. It was his last mistake.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 40%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 3 Opals and 1 Pearl</span><br/>
-<br/>
-=== Unrighteous Cause &ndash; mace ===
-<span style='color:#808080'><i>Avoid hitting too hard, it will defeat the enemy too fast and take away the fun.</i></span><br/>
-<span style='color:green'>Damage decreased by 4</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 30%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 30%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<br/>
-=== Unseen Writings &ndash; cloak ===
-<span style='color:#808080'><i>No matter how well you write, after a millenium there will be nothing of it. Though copies may survive.</i></span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 5%</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 5%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:purple'>4% to magical resistances (requires [[#Unspoken Words_.E2.80.93_gauntlets|Unspoken Words]])</span><br/>
-<span style='color:purple'>New base ranged weapon special: struggle (requires [[#Unthought Memories_.E2.80.93_amulet|Unthought Memories]])</span><br/>
-<span style='color:purple'>4% to all physical resistances (requires [[#Unsung Odes_.E2.80.93_armour|Unsung Odes]])</span><br/>
-<br/>
-=== Unspoken Words &ndash; gauntlets ===
-<span style='color:#808080'><i>No matter how wise you are, your words once shall be forgotten. But meaning may remain.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 5%</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 5%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:purple'>4% to all physical resistances (requires [[#Unseen Writings_.E2.80.93_cloak|Unseen Writings]])</span><br/>
-<span style='color:purple'>4% to magical resistances (requires [[#Unthought Memories_.E2.80.93_amulet|Unthought Memories]])</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Unsung Odes_.E2.80.93_armour|Unsung Odes]])</span><br/>
-<br/>
-=== Unsung Odes &ndash; armour ===
-<span style='color:#808080'><i>Your deeds of valour will not be revered forever. But their consequences will not vanish.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:green'>Increases all magical damages by 15%</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Unseen Writings_.E2.80.93_cloak|Unseen Writings]])</span><br/>
-<span style='color:purple'>4% to all physical resistances (requires [[#Unspoken Words_.E2.80.93_gauntlets|Unspoken Words]])</span><br/>
-<span style='color:purple'>4% to magical resistances (requires [[#Unthought Memories_.E2.80.93_amulet|Unthought Memories]])</span><br/>
-<br/>
-=== Unthought Memories &ndash; amulet ===
-<span style='color:#808080'><i>Your life's experience may disappear when you perish, but once somebody will come to the same experience.</i></span><br/>
-<span style='color:green'>Enemy resistances to fire decreased by 5%</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 5%</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:purple'>4% to all physical resistances (requires [[#Unseen Writings_.E2.80.93_cloak|Unseen Writings]])</span><br/>
-<span style='color:purple'>2% to all resistances (requires [[#Unspoken Words_.E2.80.93_gauntlets|Unspoken Words]])</span><br/>
-<span style='color:purple'>4% to magical resistances (requires [[#Unsung Odes_.E2.80.93_armour|Unsung Odes]])</span><br/>
-<br/>
-=== Vanquisher's Mithral Armour &ndash; armour ===
-<span style='color:#808080'><i>Like a tempest, he landed on his enemies, gore flying everywhere. Even his armour helped him spill blood.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>Damage increased by 30% (in EASY difficulty), 25% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 5%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== Vinegar Bath &ndash; armour ===
-<span style='color:#808080'><i>Bathe bones in vinegar, they will soften and will bend rather than break.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 35%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 10%</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<br/>
-=== Virtual Void &ndash; helm ===
-<span style='color:#808080'><i>The pure shall be overridden.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 4</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<br/>
-=== Virtue of Hope &ndash; staff ===
-<span style='color:#808080'><i>See the ones who know.</i></span><br/>
-<span style='color:green'>Increases all magical damages by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>4 more hitpoints per level per level</span><br/>
-<br/>
-=== Virulent Poison &ndash; potion ===
-<span style='color:#808080'><i>He is not only farting poison, he also sweats and burps it.</i></span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#dark aura_.E2.80.93_dummy|dark aura]]</span><br/>
-<br/>
-=== Visions of Cruelty &ndash; helm ===
-<span style='color:#808080'><i>There is cruelty. As far as I can see, cruelty is everywhere.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 10%</span><br/>
-<span style='color:green'>Damage increased by 20% (in EASY difficulty), 15% (in MEDIUM difficulty), 10% (in HARD difficulty)</span><br/>
-<br/>
-=== Void &ndash; armour ===
-<span style='color:#808080'><i>Try to cut through this. There is nothing inside, my guts are in another dimension!</i></span><br/>
-<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to arcane decreased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 25%</span><br/>
-<span style='color:#60A0FF'>Resistance to pierce increased by 25%</span><br/>
-<br/>
-=== Wanderlust &ndash; boots ===
-<span style='color:#808080'><i>See far. Go far. Know the beauty of the world.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:green'>Increases all magical damages by 5%</span><br/>
-<span style='color:#60A0FF'>2 more movement points</span><br/>
-<br/>
-=== Warheart &ndash; craftable as any armour ===
-<span style='color:#808080'><i>This will please my war loving heart.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 15%</span><br/>
-<span style='color:green'>1 more attacks</span><br/>
-<span style='color:#60A0FF'>5% chance to strike a devastating blow</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (10)]]</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Obsidians, 1 Opal, 1 Diamond, 2 Rubies and 1 Amethyst</span><br/>
-<br/>
-=== What no man should know &ndash; helm ===
-<span style='color:#808080'><i>I saw a man, frozen solid in a midsummer day. He had this pretty helmet, let me try it on...</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Resistance to impact increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 20%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#frostbite_.E2.80.93_dummy|frostbite]]</span><br/>
-<span style='color:#60A0FF'>New ability: regenerates</span><br/>
-<br/>
-=== Wicked Spear of Cruelty &ndash; spear ===
-<span style='color:#808080'><i>With horror, he realised that the horse under him had joined the walking dead.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
-<span style='color:green'>Sets damage type to cold</span><br/>
-<span style='color:green'>New weapon special: plague</span><br/>
-<br/>
-=== Widowmaker, Widowermaker &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>The number of widows will rise after this battle.</i></span><br/>
-<span style='color:green'>Damage decreased by 10%</span><br/>
-<span style='color:green'>New weapon special: charge</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#60A0FF'>Resistance to fire increased by 5%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 1 Topaz, 1 Opal, 2 Pearls and 1 Diamond</span><br/>
-<br/>
-=== Winged Axe &ndash; axe ===
-<span style='color:#808080'><i>Each day, he fought bravely in distant lands. Every night, he enjoyed his time with his wife.</i></span><br/>
-<span style='color:green'>Damage increased by 20%</span><br/>
-<span style='color:#60A0FF'>Resistance to arcane increased by 5%</span><br/>
-<span style='color:#60A0FF'>Sets alignment to neutral</span><br/>
-<span style='color:#60A0FF'>1 fewer movement points</span><br/>
-<span style='color:#60A0FF'>New ability: teleport</span><br/>
 <br/>
 === Winterclaw &ndash; sword ===
 <span style='color:#808080'><i>They come at night. They leave frozen bodies behind. Bodies that awaken.</i></span><br/>
@@ -2852,57 +3214,86 @@ The bloodline of true warriors</i></span><br/>
 <span style='color:green'>New weapon special: plague</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 10%</span><br/>
 <br/>
-=== Wisdom of the Ages &ndash; helm ===
-<span style='color:#808080'><i>There is no ancient wisdom. Knowledge must be created in present.</i></span><br/>
-<span style='color:#60A0FF'>Increases physical resistances by 5%</span><br/>
-<span style='color:#60A0FF'>Sucks 1 (in EASY difficulty) health from targets with each hit</span><br/>
-<span style='color:#60A0FF'>Spells suck 1 health from targets with each hit</span><br/>
-<span style='color:green'>Enemy resistances to cold decreased by 10%</span><br/>
-<span style='color:purple'>+1 to base attacks (requires [[#Search for Wisdom_.E2.80.93_boots|Search for Wisdom]])</span><br/>
-<span style='color:purple'>+2 base damage (requires [[#Tracking the Lost Knowledge_.E2.80.93_cloak|Tracking the Lost Knowledge]])</span><br/>
+== thunderstick ==
+=== Bean Shooter &ndash; thunderstick ===
+<span style='color:#808080'><i>Put there raw beans instead of a bullet, it will hit so many enemies.</i></span><br/>
+<span style='color:green'>Damage increased by 3</span><br/>
+<span style='color:#60A0FF'>Sucks 1 health from targets with each hit</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#cone_.E2.80.93_dummy|cone]]</span><br/>
 <br/>
-=== Woodland Cloak &ndash; cloak ===
-<span style='color:#808080'><i>Where is the elf wearing that green cloak? Has anybody seen him?</i></span><br/>
-<span style='color:#60A0FF'>New ability: ambush</span><br/>
-<span style='color:#60A0FF'>Movement costs through forests set to 1</span><br/>
+== xbow ==
+=== Ballista &ndash; xbow ===
+<span style='color:#808080'><i>Are you sure that thing is meant to be hand-held?</i></span><br/>
+<span style='color:green'>Damage increased by 120% (in EASY difficulty), 100% (in MEDIUM difficulty), 80% (in HARD difficulty)</span><br/>
 <br/>
-=== Worshipper of Darkness &ndash; cloak ===
-<span style='color:#808080'><i>Worshipping the heralds of Light is a heavy burden people think to be pleasant to carry.</i></span><br/>
-<span style='color:green'>Damage decreased by 2</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#Deathaura_.E2.80.93_heals|deathaura (8)]]</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#despair (INTENSITY)_.E2.80.93_leadership|despair (10)]]</span><br/>
+=== Ballista &ndash; xbow ===
+<span style='color:#808080'><i>Are you sure that thing is meant to be hand-held?</i></span><br/>
+<span style='color:green'>Damage increased by 120% (in EASY difficulty), 100% (in MEDIUM difficulty), 80% (in HARD difficulty)</span><br/>
 <br/>
-=== Wrath of the Pagan &ndash; mace ===
-<span style='color:#808080'><i>Law or chaos? That is just a point of view not everyone shares.</i></span><br/>
-<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+=== Black Raptor &ndash; xbow ===
+<span style='color:#808080'><i>Birds look upwards to avoid eagles. They should look down to avoid hunters.</i></span><br/>
+<span style='color:#60A0FF'>Decreases physical resistances by 20%</span><br/>
+<span style='color:green'>Damage increased by 60%</span><br/>
 <span style='color:green'>30% more attacks</span><br/>
 <span style='color:green'>New weapon special: marksman</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#chaotic and lawful_.E2.80.93_damage|chaotic and lawful]]</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
+<span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
-=== Wrathful Combat Techniques &ndash; limited ===
-<span style='color:#808080'><i>Let the anger flow through your veins.</i></span><br/>
-<span style='color:orange'>New advancements: Techniques of using anger in battle</span><br/>
+=== Chu-ko-nu &ndash; xbow ===
+<span style='color:#808080'><i>Do you even reload that thing?</i></span><br/>
+<span style='color:green'>Damage increased by 15%</span><br/>
+<span style='color:green'>55% more attacks</span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
 <br/>
-=== Wretched Defiler &ndash; craftable as any weapon ===
-<span style='color:#808080'><i>Minimise your casualties, even at the cost of defiling corpses.</i></span><br/>
-<span style='color:green'>Damage increased by 30%</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#plague (LANGUAGE_TYPE)_.E2.80.93_plague|plague (Soulless)]]</span><br/>
-<span style='color:green'>Increases all magical damages by 10%</span><br/>
-<span style='color:#000080'>Gems needed for crafting: 2 Topazes, 2 Opals and 1 Pearl</span><br/>
+=== Doomsday Machine &ndash; xbow ===
+<span style='color:#808080'><i>To spread doom, you need proper tools.</i></span><br/>
+<span style='color:green'>Damage increased by 50% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#shockwave_.E2.80.93_slow|shockwave]]</span><br/>
+<span style='color:green'>Increases all magical damages by 15%</span><br/>
 <br/>
-=== Xuanquang's Soul Harvest &ndash; polearm ===
-<span style='color:#808080'><i>Don't be afraid when seeing a bloody road. Keep calm and turn back to face the one who made it so bloody.</i></span><br/>
+=== Hatred for Men &ndash; xbow ===
+<span style='color:#808080'><i>Fuelled by the venom and hatred.</i></span><br/>
+<span style='color:green'>Damage increased by 20%</span><br/>
+<span style='color:#60A0FF'>10% chance to strike a devastating blow</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#pierce_.E2.80.93_dummy|pierce]]</span><br/>
+<span style='color:green'>New weapon special: poison</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#NAME (INTENSITY)_.E2.80.93_leadership|damage aura (10)]]</span><br/>
+<br/>
+=== Headstriker &ndash; xbow ===
+<span style='color:#808080'><i>If you have a good aim, you will hit a vulnerable spot and kill even with a lightweight bolt.</i></span><br/>
+<span style='color:green'>Damage increased by 25%</span><br/>
+<span style='color:green'>Damage increased by 2</span><br/>
+<span style='color:green'>New weapon special: marksman</span><br/>
+<span style='color:#60A0FF'>Resistance to pierce increased by 5%</span><br/>
+<br/>
+=== Orcish Ingenuity &ndash; xbow ===
+<span style='color:#808080'><i>How the hell could an orc invent this?!</i></span><br/>
 <span style='color:green'>Damage increased by 40% (in EASY difficulty), 30% (in MEDIUM difficulty), 20% (in HARD difficulty)</span><br/>
-<span style='color:green'>Merges attacks</span><br/>
-<span style='color:green'>New weapon special: [[LotI_Abilities#kamikaze sprint_.E2.80.93_damage|kamikaze sprint]]</span><br/>
-<span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
-=== Zealous Axe &ndash; axe ===
-<span style='color:#808080'><i>Let them try to attack us for we shall be those who strike first.</i></span><br/>
-<span style='color:green'>Damage increased by 45%</span><br/>
-<span style='color:#60A0FF'>Resistance to blade increased by 10%</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#zeal aura_.E2.80.93_dummy|zeal aura]]</span><br/>
-<span style='color:#60A0FF'>1 more movement points</span><br/>
+=== Relentless Fury &ndash; xbow ===
+<span style='color:#808080'><i>You tell that my hits are weak? I will show you how many of them you can survive, nothing can stop me!</i></span><br/>
+<span style='color:green'>Damage decreased by 30% (in EASY difficulty), 40% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
+<span style='color:green'>100% (in EASY difficulty), 80% (in MEDIUM difficulty), 60% (in HARD difficulty) more attacks</span><br/>
+<span style='color:#60A0FF'>24 more hitpoints per level</span><br/>
+<br/>
+=== Starbreaker &ndash; xbow ===
+<span style='color:#808080'><i>So you are good at blocking? We shall see about that!</i></span><br/>
+<span style='color:green'>Damage increased by 8 (in EASY difficulty), 5 (in MEDIUM difficulty), 2 (in HARD difficulty)</span><br/>
+<span style='color:green'>New weapon special: [[LotI_Abilities#trickery_.E2.80.93_dummy|trickery]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#conviction (INTENSITY)_.E2.80.93_resistance|conviction (15)]]</span><br/>
+<br/>
+=== The Cannon &ndash; xbow ===
+<span style='color:#808080'><i>If I will ever get to you, you will be wrecked!</i></span><br/>
+<span style='color:green'>Damage increased by 70% (in EASY difficulty), 60% (in MEDIUM difficulty), 50% (in HARD difficulty)</span><br/>
+<span style='color:green'>25% more attacks</span><br/>
+<span style='color:#60A0FF'>3 fewer movement points</span><br/>
+<br/>
+=== The Overdrawer &ndash; xbow ===
+<span style='color:#808080'><i>Draw the arrow, draw it more, more, more, and now you can shoot through enemies!</i></span><br/>
+<span style='color:green'>Damage increased by 45% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty)</span><br/>
+<br/>
+=== The Underdrawer &ndash; xbow ===
+<span style='color:#808080'><i>Shoot as much as you can, enemies will think they are facing a large army!</i></span><br/>
+<span style='color:green'>45% (in EASY difficulty), 40% (in MEDIUM difficulty), 30% (in HARD difficulty) more attacks</span><br/>
 <br/>

--- a/loti_wiki_gen/index.py
+++ b/loti_wiki_gen/index.py
@@ -56,8 +56,17 @@ class Index:
             print("BUG DETECT: Could not find advancement", name, "in", section)
 
     def query_item(self, item_name):
-        return self.item_index[item_name]
+        if item_name in self.item_index:
+            return self.item_index[item_name]
+        if self.verbose:
+            print("BUG DETECT: Could not find item", item_name)
 
+    def process_requirement(self, item_name):
+        if self.query_item(item_name.lower()):
+            return "(requires [[#{}|{}]])".format(self.query_item(item_name.lower()), item_name)
+        else:
+            return "(requires {})".format(item_name)      
+        
     def query_ability(self, ability_name):
         if ability_name in self.ability_index:
             return self.ability_index[ability_name]

--- a/loti_wiki_gen/wml_parser.py
+++ b/loti_wiki_gen/wml_parser.py
@@ -30,7 +30,8 @@ wml_regexes = [("key", r"([\w{}]+)\s*=\s*_?\s*\"([^\"]*)\""),
                ("macro_open", r"(\{[^{}]+)"),
                ("pre", r"#(define|ifdef|else|endif|enddef|ifver) ?([^\n]*)"),
                ("whitespace", r"(\s+)"),
-               ("comment", r"#[^\n]*")]
+               ("comment", r"#[^\n]*"),
+               ("text", r"_?\s*\"(.*?)\"")]
 
 levels = ["EASY", "MEDIUM", "HARD"]
 
@@ -124,7 +125,6 @@ def tokenize(text, lineno, filename):
             raise RuntimeError("Can't parse {} at {}:{}".format(repr(text[:100]), filename, lineno))
 
 
-
 def preprocess(tokens):
     tokens = iter(tokens)
     for type, value, lineno in tokens:
@@ -203,6 +203,9 @@ def subparse_wml(tokens, filename, first_lineno, tag_ann="all"):
                         raise RuntimeError("EOF while parsing macro {}".format(name))
                 tag = subparse_wml(subtokens, filename, lineno, annotation)
                 tags[name].append(tag)
+        if type == "text":
+            # text translations for the special notes in the abilities file
+            tags["text"] = value
     return WMLTag(keys, tags, tag_ann, macros, "{}:{}".format(filename, first_lineno))
 
 

--- a/loti_wiki_gen/writer.py
+++ b/loti_wiki_gen/writer.py
@@ -187,7 +187,9 @@ def ability_name(index, name, args):
         x = "regenerates ({})".format(args[0])
     elif name == "HEALS_OTHER":
         x = "heals ({})".format(args[0])
-    elif name in ("SHIELD", "DESPAIR", "CONVICTION", "FRAIL_TIDE", "UNHOLYBANE", "DEATHAURA", "CAREFUL"):
+    elif name == "LEADERSHIP_LEVEL":
+        x = "leadership (as level {} unit)".format(args[0])
+    elif name in ("SHIELD", "DESPAIR", "CONVICTION", "FRAIL_TIDE", "UNHOLYBANE", "DEATHAURA", "CAREFUL", "ANTIMAGIC"):
         x = "{} ({})".format(name.replace("_", " ").lower(), args[0])
     else:
         assert not args, name
@@ -364,7 +366,7 @@ def write_item(name, tag, file, index):
 
     for latent in tag.tags["latent"]:
         value = re.sub("\(requires ([^)]+)\)",
-                       lambda m: "(requires [[#{}|{}]])".format(index.query_item(m.group(1).lower()), m.group(1)),
+                       lambda m: index.process_requirement(m.group(1)),
                        latent.keys["desc"].any)
         write(re.sub("color='([^']+)'", "style='color:\\1'", value))
     if "description" in keys and write.writes < 3:
@@ -533,7 +535,7 @@ def write_advancement(section, name, tag, file, index):
 def write_ability(section, name, type, macro_name, tag, file, index):
     write = writer(file)
     keys = tag.keys
-    write("===", keys["name"].any, "&ndash;", type, "===", end="\n")
+    write("====", keys["name"].any, "&ndash;", type, "====", end="\n")
     write(re.sub("([^\n]+)", "<span style='color:#808080'><i>\\1</i></span>", keys["description"].any))
     write()
 

--- a/scenarios.wiki
+++ b/scenarios.wiki
@@ -1,5 +1,5 @@
-This is an auto-generated wiki page listing all the scenarios currently avalible in the campaign "Legend of the Invincibles". 
-This was generated at Wed Oct 31 20:12:22 2018 using version git-dea189d of LotI and version 0.3.5 of the generation script.
+This is an auto-generated wiki page listing all the scenarios currently available in the campaign "Legend of the Invincibles". 
+This was generated at Tue Sep 21 22:36:25 2021 using version 3.2.6d of LotI and version 0.3.5.1 of the generation script.
 As this is auto-generated, DO NOT EDIT THIS PAGE.
 Instead, create a new issue at https://github.com/matsjoyce/LotIWikiGen/issues/new and the script will be adjusted.
 
@@ -7,7 +7,7 @@ Other LotI-related wiki pages:
 
 * https://wiki.wesnoth.org/LotI_Items &ndash; items, such as weapons and books
 * https://wiki.wesnoth.org/LotI_Standard_Advancements &ndash; general advancements such as legacies and books
-* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit specific advancements
+* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit-specific advancements
 * https://wiki.wesnoth.org/LotI_Abilities &ndash; abilities and weapon specials
 * https://wiki.wesnoth.org/LotI_Scenarios &ndash; scenario information
 * https://wiki.wesnoth.org/DeadlyUnitsFromLotI
@@ -1066,20 +1066,6 @@ Other LotI-related wiki pages:
 <span style='color:#60A0FF'>Chance of a staff dropping is 7%</span><br/>
 <span style='color:#60A0FF'>Chance of a sword dropping is 14%</span><br/>
 <span style='color:#60A0FF'>Chance of a xbow dropping is 7%</span><br/>
-<br/>
-=== test &ndash; Test Scenario ===
-<span style='color:green'>Chance of a dying enemy on the side 2 dropping a weapon is 10%</span><br/>
-<span style='color:green'>Chance of a dying enemy on the side 2 dropping a gem is 13%</span><br/>
-<span style='color:#60A0FF'>Chance of a axe dropping is 17%</span><br/>
-<span style='color:#60A0FF'>Chance of a bow dropping is 17%</span><br/>
-<span style='color:#60A0FF'>Chance of a dagger dropping is 6%</span><br/>
-<span style='color:#60A0FF'>Chance of a knife dropping is 6%</span><br/>
-<span style='color:#60A0FF'>Chance of a mace dropping is 11%</span><br/>
-<span style='color:#60A0FF'>Chance of a spear dropping is 6%</span><br/>
-<span style='color:#60A0FF'>Chance of a staff dropping is 17%</span><br/>
-<span style='color:#60A0FF'>Chance of a sword dropping is 17%</span><br/>
-<span style='color:#60A0FF'>Chance of a xbow dropping is 6%</span><br/>
-<span style='color:#B81413'>Beelzebub will spawn at 16, 17 and will release 2 flies per turn</span><br/>
 <br/>
 
 == Chapter 7 ==

--- a/standard_advancements.wiki
+++ b/standard_advancements.wiki
@@ -1,5 +1,5 @@
-This is an auto-generated wiki page listing all the advancements avalible for catagories of units currently avalible in the campaign "Legend of the Invincibles". See https://wiki.wesnoth.org/LotI_Unit_Advancements for unit specific advancements.
-This was generated at Wed Oct 31 20:12:22 2018 using version git-dea189d of LotI and version 0.3.5 of the generation script.
+This is an auto-generated wiki page listing all the advancements available for categories of units currently available in the campaign "Legend of the Invincibles". See https://wiki.wesnoth.org/LotI_Unit_Advancements for unit-specific advancements.
+This was generated at Tue Sep 21 22:36:25 2021 using version 3.2.6d of LotI and version 0.3.5.1 of the generation script.
 As this is auto-generated, DO NOT EDIT THIS PAGE.
 Instead, create a new issue at https://github.com/matsjoyce/LotIWikiGen/issues/new and the script will be adjusted.
 
@@ -7,7 +7,7 @@ Other LotI-related wiki pages:
 
 * https://wiki.wesnoth.org/LotI_Items &ndash; items, such as weapons and books
 * https://wiki.wesnoth.org/LotI_Standard_Advancements &ndash; general advancements such as legacies and books
-* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit specific advancements
+* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit-specific advancements
 * https://wiki.wesnoth.org/LotI_Abilities &ndash; abilities and weapon specials
 * https://wiki.wesnoth.org/LotI_Scenarios &ndash; scenario information
 * https://wiki.wesnoth.org/DeadlyUnitsFromLotI
@@ -228,13 +228,13 @@ Other LotI-related wiki pages:
 === Possessing the Leadership of a Level 3 Unit (How to be an Overlord) &ndash; HtbaO1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement HtbaO to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === Possessing the Leadership of a Level 4 Unit (How to be an Overlord) &ndash; HtbaO2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Possessing_the_Leadership_of_a_Level_3_Unit_(How_to_be_an_Overlord)_.E2.80.93_HtbaO1|HtbaO1]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 3</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === Leading Allies to Charge into Battle (How to be an Overlord) &ndash; HtbaO2b ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -244,8 +244,8 @@ Other LotI-related wiki pages:
 === Possessing the Leadership of a Level 5 Unit (How to be an Overlord) &ndash; HtbaO3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Possessing_the_Leadership_of_a_Level_4_Unit_(How_to_be_an_Overlord)_.E2.80.93_HtbaO2|HtbaO2]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Able to Cast Fireball (Serendipity) &ndash; Srn1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -342,13 +342,13 @@ Other LotI-related wiki pages:
 <br/>
 === Dealing More Damage After an Adjacent Ally is Hit (The Doctrine of Vindictiveness) &ndash; DoV2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements DoV and [[#Dealing_More_Damage_After_Being_Hit_(The_Doctrine_of_Vindictiveness)_.E2.80.93_DoV1|DOV1]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements DoV and [[#Dealing_More_Damage_After_Being_Hit_(The_Doctrine_of_Vindictiveness)_.E2.80.93_DoV1|DoV1]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#vindictive_.E2.80.93_dummy|vindictive]]</span><br/>
 <br/>
 === After Being Hit, Dealing More Damage to that Type (The Doctrine of Vindictiveness) &ndash; DoV3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements DoV and [[#Dealing_More_Damage_After_an_Adjacent_Ally_is_Hit_(The_Doctrine_of_Vindictiveness)_.E2.80.93_DoV2|DOV2]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#vindictive_.E2.80.93_dummy|vindictive]]</span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements DoV and [[#Dealing_More_Damage_After_an_Adjacent_Ally_is_Hit_(The_Doctrine_of_Vindictiveness)_.E2.80.93_DoV2|DoV2]] to be achieved first</i></span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#unforgiving_.E2.80.93_dummy|unforgiving]]</span><br/>
 <br/>
 === 15%/5%/5%/-5% to Fire/Blade/Impact/Cold Resistance, 1 More Melee Damage (Fire Dragon Legacy) &ndash; FDL1 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
@@ -854,13 +854,13 @@ Other LotI-related wiki pages:
 === Able to Lead Allies into Battle (Leadership of a Level 4 Unit) &ndash; Leadership1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement leadership to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === Able to Lead Allies into Battle (Leadership of a Level 5 Unit) &ndash; Leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Lead_Allies_into_Battle_(Leadership_of_a_Level_4_Unit)_.E2.80.93_Leadership1|leadership1]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Able to Lead Allies into Battle to Fight Like Furious Savages &ndash; Leadership3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -929,52 +929,52 @@ Other LotI-related wiki pages:
 <span style='color:green'>Damage decreased by 7 for the lightning attack</span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
-=== Casting Lightnings Better &ndash; Lightning3 ===
+=== Casting Lightnings Faster &ndash; Lightning3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]] and [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]] and [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]] and [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 5 for the lightning attack</span><br/>
 <br/>
 === Using Lightnings Very Very Very Fast &ndash; Lightning4_firststrike ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lightning attack: firststrike</span><br/>
 <span style='color:green'>Damage decreased by 3 for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 4 for the lightning attack</span><br/>
 <br/>
 === Using Lightnings Without Need to be at Good Health &ndash; Lightning5_noswarm ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] to be achieved first</i></span><br/>
 <span style='color:green'>Remove weapon special for the lightning attack: swarm</span><br/>
 <span style='color:green'>1 fewer attacks for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning6 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 3 for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Faster &ndash; Lightning6_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6|lightning6]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6|lightning6]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2 for the lightning attack</span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning7 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6|lightning6]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6|lightning6]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Faster &ndash; Lightning7_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6|lightning6]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning7|lightning7]] and [[#Shooting_Lightnings_Faster_.E2.80.93_Lightning6_speed|lightning6_speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5|lightning5]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6|lightning6]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning7|lightning7]] and [[#Shooting_Lightnings_Faster_.E2.80.93_Lightning6_speed|lightning6_speed]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2 for the lightning attack</span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
@@ -1170,52 +1170,52 @@ Other LotI-related wiki pages:
 <span style='color:green'>Damage decreased by 10 for the lightning attack</span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
-=== Casting Lightnings Better &ndash; Lightning3 ===
+=== Casting Lightnings Faster &ndash; Lightning3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]] and [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]] and [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]] and [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 5 for the lightning attack</span><br/>
 <br/>
 === Using Lightnings Very Very Very Fast (Firststrike) &ndash; Lightning4_firststrike ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lightning attack: firststrike</span><br/>
 <span style='color:green'>Damage decreased by 3 for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 4 for the lightning attack</span><br/>
 <br/>
 === Using Lightnings Without Need to be at Good Health &ndash; Lightning5_noswarm ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] to be achieved first</i></span><br/>
 <span style='color:green'>Remove weapon special for the lightning attack: swarm</span><br/>
 <span style='color:green'>1 fewer attacks for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning6 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 4 for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Faster &ndash; Lightning6_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6_2|lightning6]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6_2|lightning6]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2 for the lightning attack</span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Better &ndash; Lightning7 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6_2|lightning6]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]] and [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6_2|lightning6]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 3 for the lightning attack</span><br/>
 <br/>
 === Shooting Lightnings Faster &ndash; Lightning7_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Better_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6_2|lightning6]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning7_2|lightning7]] and [[#Shooting_Lightnings_Faster_.E2.80.93_Lightning6_speed_2|lightning6_speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Capable_to_Use_Lightning_(Huge_Damage,_Few_Attacks)_.E2.80.93_Lightning1_2|lightning1]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning2_2|lightning2]], [[#Casting_Lightnings_Faster_.E2.80.93_Lightning3_2|lightning3]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning4_2|lightning4]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning5_2|lightning5]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning6_2|lightning6]], [[#Shooting_Lightnings_Better_.E2.80.93_Lightning7_2|lightning7]] and [[#Shooting_Lightnings_Faster_.E2.80.93_Lightning6_speed_2|lightning6_speed]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2 for the lightning attack</span><br/>
 <span style='color:green'>1 more attacks for the lightning attack</span><br/>
 <br/>
@@ -1453,7 +1453,7 @@ Other LotI-related wiki pages:
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Blast_Enemies_with_Entropic_Chaos_.E2.80.93_Entropy1|entropy1]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the entropy attack: slow</span><br/>
 <br/>
-=== Blasting Enemies with Entropy Better &ndash; Entropy2 ===
+=== Blasting Enemies with Entropy Faster &ndash; Entropy2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Blast_Enemies_with_Entropic_Chaos_.E2.80.93_Entropy1|entropy1]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the entropy attack</span><br/>
@@ -1461,22 +1461,22 @@ Other LotI-related wiki pages:
 <br/>
 === Poisoning Enemies with Entropical Blasts &ndash; Entropy2_poison ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy2|entropy2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Faster_.E2.80.93_Entropy2|entropy2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the entropy attack: poison</span><br/>
 <br/>
-=== Blasting Enemies with Entropy Better &ndash; Entropy3 ===
+=== Blasting Enemies with Entropy Faster &ndash; Entropy3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy2|entropy2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Faster_.E2.80.93_Entropy2|entropy2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the entropy attack</span><br/>
 <br/>
 === Dazzling Enemies with Entropical Blasts &ndash; Entropy3_dazzle ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy3|entropy3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Faster_.E2.80.93_Entropy3|entropy3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the entropy attack: [[LotI_Abilities#dazzle_.E2.80.93_dummy|dazzle]]</span><br/>
 <br/>
 === Blasting Enemies with Entropy Better &ndash; Entropy4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy3|entropy3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Faster_.E2.80.93_Entropy3|entropy3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the entropy attack</span><br/>
 <br/>
 === Maiming Enemies with Entropical Blasts &ndash; Entropy4_mayhem ===
@@ -1484,7 +1484,7 @@ Other LotI-related wiki pages:
 <span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy4|entropy4]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the entropy attack: [[LotI_Abilities#mayhem_.E2.80.93_dummy|mayhem]]</span><br/>
 <br/>
-=== Blasting Enemies with Entropy Better &ndash; Entropy5 ===
+=== Blasting Enemies with Entropy Faster &ndash; Entropy5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy4|entropy4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the entropy attack</span><br/>
@@ -1492,12 +1492,12 @@ Other LotI-related wiki pages:
 <br/>
 === Incinerating Enemies with Entropical Blasts &ndash; Entropy5_burn ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy5|entropy5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Faster_.E2.80.93_Entropy5|entropy5]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the entropy attack: [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
 <br/>
 === Blasting Enemies with Entropy Better &ndash; Entropy6 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Better_.E2.80.93_Entropy5|entropy5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Blasting_Enemies_with_Entropy_Faster_.E2.80.93_Entropy5|entropy5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the entropy attack</span><br/>
 <br/>
 === Turning Enemies into Zombies with Entropical Blasts &ndash; Entropy6_zombification ===

--- a/unit_advancements.wiki
+++ b/unit_advancements.wiki
@@ -1,5 +1,5 @@
-This is an auto-generated wiki page listing all the advancements that are unit specific currently avalible in the campaign "Legend of the Invincibles". See https://wiki.wesnoth.org/LotI_Standard_Advancements for general advancements such as legacies and books.
-This was generated at Wed Oct 31 20:12:22 2018 using version git-dea189d of LotI and version 0.3.5 of the generation script.
+This is an auto-generated wiki page listing all the advancements that are unit specific currently available in the campaign "Legend of the Invincibles". See https://wiki.wesnoth.org/LotI_Standard_Advancements for general advancements such as legacies and books.
+This was generated at Tue Sep 21 22:36:25 2021 using version 3.2.6d of LotI and version 0.3.5.1 of the generation script.
 As this is auto-generated, DO NOT EDIT THIS PAGE.
 Instead, create a new issue at https://github.com/matsjoyce/LotIWikiGen/issues/new and the script will be adjusted.
 
@@ -7,7 +7,7 @@ Other LotI-related wiki pages:
 
 * https://wiki.wesnoth.org/LotI_Items &ndash; items, such as weapons and books
 * https://wiki.wesnoth.org/LotI_Standard_Advancements &ndash; general advancements such as legacies and books
-* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit specific advancements
+* https://wiki.wesnoth.org/LotI_Unit_Advancements &ndash; unit-specific advancements
 * https://wiki.wesnoth.org/LotI_Abilities &ndash; abilities and weapon specials
 * https://wiki.wesnoth.org/LotI_Scenarios &ndash; scenario information
 * https://wiki.wesnoth.org/DeadlyUnitsFromLotI
@@ -87,19 +87,19 @@ Special Notes: This unit has magical attacks, which always have a high chance of
 <span style='color:#808080'><i>An ancient demoness is a creature living since time immemorial, powerful enough to survive eons. They were either born with that power, or achieved it by arcane means, collecting powerful spells and artifacts of power, or a combination of the two. In any case, their survival was more likely because of great intelligence than because of luck. They know how to get through anything alive, and because of this, all their schemes have backdoors and escape routes. If their alliance turns out to be weak, they turn their coat and join the winners or escape. If they lead an army into a battle that shows to be going to be a defeat, they betray their soldiers and flee into safety or trick the winners that they were helping them all the time. If their keep is under siege, they prepare a flight instead of a defence or a last stand.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Better at Axe Combat &ndash; axe ===
+=== Faster at Axe Combat &ndash; axe ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Faster at Axe Combat &ndash; axe-speed ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Axe_Combat_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 (melee attacks only)</span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Better at Axe Combat &ndash; axe-damage ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Axe_Combat_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === Striking More Precisely with Axe &ndash; axe-marksman ===
@@ -131,7 +131,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
-=== Better with Fireball &ndash; fireball2 ===
+=== Faster with Fireball &ndash; fireball2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball|fireball]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the fireball attack</span><br/>
@@ -139,7 +139,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Fireball &ndash; fireball3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball2|fireball2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2|fireball2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
 === Hitting More Enemies with Fireball &ndash; fireball-cone ===
@@ -174,40 +174,40 @@ This unit also has generic AMLA advancements</i></span>
 Special Notes: This unit has magical attacks, which always have a high chance of hitting an opponent. During battle, this unit can drain life from victims to renew its own health. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit can move unseen in deep water, requiring no air from the surface.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Better at Melee Combat &ndash; melee ===
+=== Faster at Melee Combat &ndash; melee ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Creating Zombies from Enemies Killed at Melee &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): plague</span><br/>
 <br/>
 === Better at Melee &ndash; melee3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_melee|melee]] and [[#Creating_Zombies_from_Enemies_Killed_at_Melee_.E2.80.93_melee2|melee2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_melee|melee]] and [[#Creating_Zombies_from_Enemies_Killed_at_Melee_.E2.80.93_melee2|melee2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === A Better Caster &ndash; magic ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
-=== A Better Caster of Chill Tempests &ndash; magic-chill ===
+=== A Faster Caster of Chill Tempests &ndash; magic-chill ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the chill tempest attack</span><br/>
 <br/>
 === Slowing with Chill Tempest &ndash; magic-chill3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the chill tempest attack: slow</span><br/>
 <br/>
-=== A Better Caster of Shadow Waves &ndash; magic-shadow ===
+=== A Faster Caster of Shadow Waves &ndash; magic-shadow ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the shadow wave attack</span><br/>
 <br/>
 === A Better Caster of Chill Tempests &ndash; magic-chill2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#A_Better_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] and [[#A_Better_Caster_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] and [[#A_Better_Caster_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the chill tempest attack</span><br/>
 <br/>
 === Slowing Multiple Enemies with Chill Tempest &ndash; magic-chill-slow-extra ===
@@ -217,10 +217,10 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === A Better Caster of Shadow Waves &ndash; magic-shadow2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#A_Better_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow|magic-shadow]] and [[#A_Better_Caster_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#A_Faster_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow|magic-shadow]] and [[#A_Better_Caster_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the shadow wave attack</span><br/>
 <br/>
-=== Leeching Enemies with Shadow Wave &ndash; magic-shadow-leech ===
+=== Leeching Health from Enemies with Shadow Wave &ndash; magic-shadow-leech ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow2|magic-shadow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the shadow wave attack: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
@@ -251,12 +251,12 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Melee Combat &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === Transforming Enemies into Soulless Also with the Infection &ndash; melee3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): [[LotI_Abilities#greater infect_.E2.80.93_poison|greater infect]]</span><br/>
 <span style='color:green'>Remove weapon special (melee attacks only): infect</span><br/>
 <br/>
@@ -282,7 +282,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === A Better Caster of Shadow Waves &ndash; magic-shadow2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow|magic-shadow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow_2|magic-shadow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the shadow wave attack</span><br/>
 <br/>
 === Creating Ghosts from Victims of Shadow Wave &ndash; magic-shadow3 ===
@@ -350,7 +350,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lightbeam attack</span><br/>
 <br/>
-=== Better with Magic &ndash; lightbeam2 ===
+=== Faster with Magic &ndash; lightbeam2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_lightbeam|lightbeam]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the lightbeam attack</span><br/>
@@ -358,17 +358,17 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Magic &ndash; lightbeam3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_lightbeam2|lightbeam2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Magic_.E2.80.93_lightbeam2|lightbeam2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lightbeam attack</span><br/>
 <br/>
-=== Better with Mace &ndash; mace ===
+=== Faster with Mace &ndash; mace ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the mace attack</span><br/>
 <span style='color:green'>1 more attacks for the mace attack</span><br/>
 <br/>
 === Better with Mace &ndash; mace2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Mace_.E2.80.93_mace|mace]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Mace_.E2.80.93_mace|mace]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the mace attack</span><br/>
 <br/>
 === Able to Heal Allies Better &ndash; heal ===
@@ -459,7 +459,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>Damage decreased by 9 for the crossbow attack</span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 3%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 3%</span><br/>
@@ -515,7 +515,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
-=== Striking Better with Bow &ndash; bow2 ===
+=== Striking Faster with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
@@ -523,23 +523,23 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
-=== Striking More Precisely with Bow &ndash; bow-precision ===
+=== Shooting Insanely Precisely &ndash; bow-precision ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
 <span style='color:green'>Remove weapon special for the bow attack: marksman</span><br/>
 <br/>
-=== Able to Shoot a Storm on Arrows Without Giving the Enemy a Chance to Counterattack &ndash; arrowstorm ===
+=== Able to Shoot a Storm on Arrows Without Giving the Enemy a Chance to Counterattack (New Attack) &ndash; arrowstorm ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: arrow storm (-20% - -40% ranged)</span><br/>
 <span style='color:green'>New weapon special for the arrow storm attack: [[LotI_Abilities#distant attack_.E2.80.93_attacks|distant attack]]</span><br/>
 <br/>
 === Shooting Arrow Storms Better &ndash; arrowstorm2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Shoot_a_Storm_on_Arrows_Without_Giving_the_Enemy_a_Chance_to_Counterattack_.E2.80.93_arrowstorm|arrowstorm]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Shoot_a_Storm_on_Arrows_Without_Giving_the_Enemy_a_Chance_to_Counterattack_(New_Attack)_.E2.80.93_arrowstorm|arrowstorm]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the arrow storm attack</span><br/>
 <span style='color:green'>5% more attacks for the arrow storm attack</span><br/>
 <br/>
@@ -547,7 +547,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Striking Better with Sword &ndash; sword2 ===
+=== Striking Faster with Sword &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Sword_.E2.80.93_sword|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the sword attack</span><br/>
@@ -555,7 +555,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Better Protected from Physical Blows (2% Better Resistances) &ndash; armour ===
@@ -586,12 +586,12 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Incinerating Enemies with Sword &ndash; sword-incinerate ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Sword_.E2.80.93_sword2_2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the sword attack: [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_2|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_2|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_2|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Stomping Enemies Better &ndash; stomp ===
@@ -602,7 +602,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
-=== Better with Fireball &ndash; fireball2 ===
+=== Faster with Fireball &ndash; fireball2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball_2|fireball]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the fireball attack</span><br/>
@@ -610,7 +610,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Fireball &ndash; fireball3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball2_2|fireball2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2_2|fireball2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
 === Creating Spirits of Fire with Fireball &ndash; fireball_plague ===
@@ -638,7 +638,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>Remove weapon special for the claws attack: backstab</span><br/>
 <span style='color:green'>Damage increased by 1 for the claws attack</span><br/>
 <br/>
-=== Clawing Better &ndash; claws3 ===
+=== Clawing Faster &ndash; claws3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Clawing_Better_.E2.80.93_claws|claws]] and [[#Clawing_Better_.E2.80.93_claws2|claws2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the claws attack</span><br/>
@@ -646,26 +646,26 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Clawing Better &ndash; claws4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Clawing_Better_.E2.80.93_claws|claws]], [[#Clawing_Better_.E2.80.93_claws2|claws2]] and [[#Clawing_Better_.E2.80.93_claws3|claws3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Clawing_Better_.E2.80.93_claws|claws]], [[#Clawing_Better_.E2.80.93_claws2|claws2]] and [[#Clawing_Faster_.E2.80.93_claws3|claws3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the claws attack</span><br/>
 <br/>
 === Draining Enemies Better &ndash; sip ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the soul sip attack</span><br/>
 <br/>
-=== Draining Enemies Better &ndash; sip2 ===
+=== Draining Enemies Faster &ndash; sip2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Draining_Enemies_Better_.E2.80.93_sip|sip]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the soul sip attack</span><br/>
 <br/>
 === Draining More from Living, Able to Drain a Bit from the Non-Living as Well &ndash; sip3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Draining_Enemies_Better_.E2.80.93_sip|sip]] and [[#Draining_Enemies_Better_.E2.80.93_sip2|sip2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Draining_Enemies_Better_.E2.80.93_sip|sip]] and [[#Draining_Enemies_Faster_.E2.80.93_sip2|sip2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the soul sip attack: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
 <br/>
 === Draining Enemies Better &ndash; sip4 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Draining_Enemies_Better_.E2.80.93_sip|sip]] and [[#Draining_Enemies_Better_.E2.80.93_sip2|sip2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Draining_Enemies_Better_.E2.80.93_sip|sip]] and [[#Draining_Enemies_Faster_.E2.80.93_sip2|sip2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the soul sip attack</span><br/>
 <br/>
 === Faster &ndash; movement ===
@@ -687,7 +687,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Better at Melee Combat &ndash; axe3 ===
+=== Faster at Melee Combat &ndash; axe3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe|axe]] and [[#Better_at_Melee_Combat_.E2.80.93_axe2|axe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 (melee attacks only)</span><br/>
@@ -695,21 +695,21 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Melee Combat &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe|axe]], [[#Better_at_Melee_Combat_.E2.80.93_axe2|axe2]] and [[#Better_at_Melee_Combat_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe|axe]], [[#Better_at_Melee_Combat_.E2.80.93_axe2|axe2]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Able to Attack in a Terrible Way that Lowers Enemy Resistance &ndash; doom ===
+=== Able to Attack in a Terrible Way that Lowers Enemy Resistance (New Attack) &ndash; doom ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: doom (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the doom attack: [[LotI_Abilities#doom_.E2.80.93_dummy|doom]]</span><br/>
 <br/>
 === Crippling Enemies Better &ndash; doom2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_.E2.80.93_doom|doom]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_(New_Attack)_.E2.80.93_doom|doom]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the doom attack</span><br/>
 <span style='color:green'>5% more attacks for the doom attack</span><br/>
 <br/>
-=== Better at Blocking Attacks &ndash; block ===
+=== Better at Blocking Attacks (Lowering the Chance to be Hit by 4%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 4%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 4%</span><br/>
@@ -729,19 +729,19 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
-=== Better with Crossbow &ndash; xbow2 ===
+=== Faster with Crossbow &ndash; xbow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
 === Shooting Poisonous Arrows &ndash; xbow-poison ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the crossbow attack: poison</span><br/>
 <br/>
 === Better with Crossbow &ndash; xbow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
 === Better Resistance (2% Blade, 2% Pierce, 3% Cold, But -1% Arcane) &ndash; armour ===
@@ -758,7 +758,7 @@ This unit also has generic AMLA advancements</i></span>
 
 == Demigod (Efraim God) ==
 <span style='color:#808080'><i>Half-gods are things so rare, that nobody ever cared to describe their full powers.<br/>
-Special notes: Telling everything a half-god can do would be too lengthy. But a matter to consider is that they have developed compassion out of a desire to save their wretched enemies from sins, pain, suffering and misery, they are able to redeem tormented souls. Even if this 'redeem attack' can be used only once every three turns.<br/>
+Special Notes: Telling everything a half-god can do would be too lengthy. But a matter to consider is that they have developed compassion out of a desire to save their wretched enemies from sins, pain, suffering and misery, they are able to redeem tormented souls. Even if this 'redeem attack' can be used only once every three turns.<br/>
 Gameplay notes:<br/>
 It is imperative to use the redeem attack from time to time. After redeeming a certain amount of enemies, redeem becomes more effective (possibly also a good offensive weapon) and the unit gains a new advancement line of choice. Some of them add new spells, others add new abilities. Spells gained have huge ranges, incomparable to other spells, and converge into Particle storm, an attack hitting many enemies and dealing severe arcane damage. Physical abilities converge into Spiritual Transformation, that is an attack that makes the unit attack a single target with huge damage and taking only 33% of the damage.<br/>
 Without these advancements, the unit will never get particularly strong, and low level enemies may become rare to find.<br/>
@@ -1055,7 +1055,7 @@ This unit also has god AMLA advancements</i></span>
 
 == Demigod (Lethalia God) ==
 <span style='color:#808080'><i>Half-gods are things so rare, that nobody ever cared to describe their full powers.<br/>
-Special notes: Telling everything a half-god can do would be too lengthy. But a matter to consider is that they have developed compassion out of a desire to save their wretched enemies from sins, pain, suffering and misery, they are able to redeem tormented souls. Even if this 'redeem attack' can be used only once every three turns.<br/>
+Special Notes: Telling everything a half-god can do would be too lengthy. But a matter to consider is that they have developed compassion out of a desire to save their wretched enemies from sins, pain, suffering and misery, they are able to redeem tormented souls. Even if this 'redeem attack' can be used only once every three turns.<br/>
 Gameplay notes:<br/>
 It is imperative to use the redeem attack from time to time. After redeeming a certain amount of enemies, redeem becomes more effective (possibly also a good offensive weapon) and the unit gains a new advancement line of choice. Some of them add new spells, others add new abilities. Spells gained have huge ranges, incomparable to other spells, and converge into Particle storm, an attack hitting many enemies and dealing severe arcane damage. Physical abilities converge into Spiritual Transformation, that is an attack that makes the unit attack a single target with huge damage and taking only 33% of the damage.<br/>
 Without these advancements, the unit will never get particularly strong, and low level enemies may become rare to find.<br/>
@@ -1418,18 +1418,18 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Faster at Melee Combat &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 (melee attacks only)</span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Creating Zombies from Enemies Killed at Melee &ndash; melee3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): plague</span><br/>
 <br/>
 === Better at Melee &ndash; melee3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === A Better Caster &ndash; magic ===
@@ -1442,29 +1442,29 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Slowing with Chill Tempest &ndash; magic-chill3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill_2|magic-chill]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the chill tempest attack: slow</span><br/>
 <br/>
 === A Better Caster of Chill Tempests &ndash; magic-chill2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill_2|magic-chill]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the chill tempest attack</span><br/>
 <br/>
-=== A Better Caster of Shadow Waves &ndash; magic-shadow ===
+=== A Faster Caster of Shadow Waves &ndash; magic-shadow ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the shadow wave attack</span><br/>
 <br/>
 === A Better Caster of Chill Tempests &ndash; magic-chill2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill|magic-chill]] and [[#A_Better_Caster_.E2.80.93_magic_2|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#A_Faster_Caster_of_Chill_Tempests_.E2.80.93_magic-chill_2|magic-chill]] and [[#A_Better_Caster_.E2.80.93_magic_2|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the chill tempest attack</span><br/>
 <br/>
 === A Better Caster of Shadow Waves &ndash; magic-shadow2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#A_Better_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow_2|magic-shadow]] and [[#A_Better_Caster_.E2.80.93_magic_2|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#A_Faster_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow_3|magic-shadow]] and [[#A_Better_Caster_.E2.80.93_magic_2|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the shadow wave attack</span><br/>
 <br/>
-=== Leeching Enemies with Shadow Wave &ndash; magic-shadow-leech ===
+=== Leeching Health from Enemies with Shadow Wave &ndash; magic-shadow-leech ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Caster_of_Shadow_Waves_.E2.80.93_magic-shadow2_3|magic-shadow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the shadow wave attack: [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
@@ -1521,7 +1521,8 @@ Special Notes: This unit has magical attacks, which always have a high chance of
 <br/>
 
 == Demon Queen (Uria) ==
-<span style='color:#808080'><i>This is Uria, the worst thing ever known to mankind after the Fall. She is frequently considered to be the ultimate evil, and the source of evil.</i></span>
+<span style='color:#808080'><i>This is Uria, the worst thing ever known to mankind after the Fall. She is frequently considered to be the ultimate evil, and the source of evil.<br/>
+Special Notes: This unit has magical attacks, which always have a high chance of hitting an opponent. This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn. The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures. During battle, this unit can drain life from victims to renew its own health. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit’s skill at skirmishing allows it to ignore enemies’ zones of control and thus move unhindered around them. This unit is able to hide at night, leaving no trace of its presence. This unit’s marksmanship gives it a high chance of hitting targeted enemies, but only on the attack.</i></span>
 
 ===  &ndash; amla_demon_lord ===
 <span style='color:#808080'><i>This advancement can be taken 100 times</i></span><br/>
@@ -1530,7 +1531,8 @@ Special Notes: This unit has magical attacks, which always have a high chance of
 <br/>
 
 == Demon Queen's Avatar (Uria Avatar) ==
-<span style='color:#808080'><i>This is Uria, the worst thing ever known to mankind after the Fall. She is frequently considered to be the ultimate evil, and the source of all evil.</i></span>
+<span style='color:#808080'><i>This is Uria, the worst thing ever known to mankind after the Fall. She is frequently considered to be the ultimate evil, and the source of all evil.<br/>
+Special Notes: This unit has magical attacks, which always have a high chance of hitting an opponent. This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn. The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures. During battle, this unit can drain life from victims to renew its own health. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit’s skill at skirmishing allows it to ignore enemies’ zones of control and thus move unhindered around them. This unit is able to hide at night, leaving no trace of its presence.</i></span>
 
 ===  &ndash; amla_demon_lord ===
 <span style='color:#808080'><i>This advancement can be taken 100 times</i></span><br/>
@@ -1557,7 +1559,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the scourge attack</span><br/>
 <br/>
-=== Striking More Furiously with Scourge &ndash; scourge2 ===
+=== Striking Faster with Scourge &ndash; scourge2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_More_Furiously_with_Scourge_.E2.80.93_scourge|scourge]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 5 for the scourge attack</span><br/>
@@ -1565,18 +1567,18 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking More Furiously with Scourge &ndash; scourge3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_More_Furiously_with_Scourge_.E2.80.93_scourge2|scourge2]] and [[#Striking_More_Furiously_with_Scourge_.E2.80.93_scourge|scourge]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Scourge_.E2.80.93_scourge2_2|scourge2]] and [[#Striking_More_Furiously_with_Scourge_.E2.80.93_scourge|scourge]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the scourge attack</span><br/>
 <br/>
-=== Able to Enter a Battle Frenzy Like Dwarves, But Only when Attacking &ndash; berserk ===
+=== Able to Enter a Battle Frenzy Like Dwarves, But Only when Attacking (New Attack) &ndash; berserk ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_More_Furiously_with_Scourge_.E2.80.93_scourge|scourge]] to be achieved first</i></span><br/>
 <span style='color:green'>New attack: mace_berserk (7 - 5, impact)</span><br/>
 <span style='color:green'>New weapon special for the mace_berserk attack: [[LotI_Abilities#lesser berserk (COUNT)_.E2.80.93_berserk|lesser berserk (3)]]</span><br/>
 <br/>
-=== Striking Better when in Battle Frenzy &ndash; berserk2 ===
+=== Striking Faster when in Battle Frenzy &ndash; berserk2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Enter_a_Battle_Frenzy_Like_Dwarves,_But_Only_when_Attacking_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Enter_a_Battle_Frenzy_Like_Dwarves,_But_Only_when_Attacking_(New_Attack)_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the mace_berserk attack</span><br/>
 <br/>
 === Better Protected from Physical Blows (2% Better Resistances; +4% Resist Impact) &ndash; armour ===
@@ -1595,34 +1597,34 @@ This unit also has generic AMLA advancements</i></span>
 Special Notes: Using a charging attack doubles both damage dealt and received; this does not affect defensive retaliation. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit is capable of basic healing. This unit has magical attacks, which always have a high chance of hitting an opponent.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Swinging Better with the Sword &ndash; sword ===
+=== Swinging Faster with the Sword &ndash; sword ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Swinging More Precisely with the Sword &ndash; sword1_precision ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Swinging_Better_with_the_Sword_.E2.80.93_sword|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Swinging_Faster_with_the_Sword_.E2.80.93_sword|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the sword attack: marksman</span><br/>
 <br/>
 === Swinging Better with the Sword &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Swinging_Better_with_the_Sword_.E2.80.93_sword|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Swinging_Faster_with_the_Sword_.E2.80.93_sword|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Swinging Better with the Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Swinging_Better_with_the_Sword_.E2.80.93_sword|sword]] and [[#Swinging_Better_with_the_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Swinging_Faster_with_the_Sword_.E2.80.93_sword|sword]] and [[#Swinging_Better_with_the_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Swinging Faster with the Sword &ndash; sword3_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Swinging_Better_with_the_Sword_.E2.80.93_sword|sword]], [[#Swinging_Better_with_the_Sword_.E2.80.93_sword2|sword2]] and [[#Swinging_Better_with_the_Sword_.E2.80.93_sword3|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Swinging_Faster_with_the_Sword_.E2.80.93_sword|sword]], [[#Swinging_Better_with_the_Sword_.E2.80.93_sword2|sword2]] and [[#Swinging_Better_with_the_Sword_.E2.80.93_sword3|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Swinging Better with the Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken 30 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Swinging_Better_with_the_Sword_.E2.80.93_sword|sword]], [[#Swinging_Better_with_the_Sword_.E2.80.93_sword2|sword2]] and [[#Swinging_Better_with_the_Sword_.E2.80.93_sword3|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Swinging_Faster_with_the_Sword_.E2.80.93_sword|sword]], [[#Swinging_Better_with_the_Sword_.E2.80.93_sword2|sword2]] and [[#Swinging_Better_with_the_Sword_.E2.80.93_sword3|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Striking Better with Lance and Charging More Powerfully (2.5 Times More Damage) &ndash; lance ===
@@ -1783,7 +1785,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Melee Combat &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee_3|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 (melee attacks only)</span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
@@ -1916,7 +1918,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
-=== Striking Better with Lance &ndash; lance2 ===
+=== Striking Faster with Lance &ndash; lance2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 3 for the lance attack</span><br/>
@@ -1924,19 +1926,19 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Charging More Powerfully with Lance (2.5 Times More Damage) &ndash; lance3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]] and [[#Striking_Better_with_Lance_.E2.80.93_lance2|lance2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]] and [[#Striking_Faster_with_Lance_.E2.80.93_lance2|lance2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (2.5)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Charging Even More Powerfully with the Lance (3 Times More Damage) &ndash; lance4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]], [[#Striking_Better_with_Lance_.E2.80.93_lance2|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3|lance3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]], [[#Striking_Faster_with_Lance_.E2.80.93_lance2|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3|lance3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (3)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Striking Even Better with the Lance &ndash; lance5 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]] and [[#Striking_Better_with_Lance_.E2.80.93_lance2|lance2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance|lance]] and [[#Striking_Faster_with_Lance_.E2.80.93_lance2|lance2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
 === Commanding the Dragon to Breathe Fire Better &ndash; fire ===
@@ -1960,25 +1962,25 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Able to Lead Allies into Battle (Like a Level 2 Unit) &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 2</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 2 unit)]]</span><br/>
 <br/>
 === Able to Lead Allies into Battle (Like a Level 3 Unit) &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Lead_Allies_into_Battle_(Like_a_Level_2_Unit)_.E2.80.93_leadership|leadership]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 2</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 2 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === A Greater Leader in Battle (Like a Level 4 Unit) &ndash; leadership3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Lead_Allies_into_Battle_(Like_a_Level_3_Unit)_.E2.80.93_leadership2|leadership2]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 3</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === A Greater Leader in Battle (Like a Proper Level 5 Unit) &ndash; leadership4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Greater_Leader_in_Battle_(Like_a_Level_4_Unit)_.E2.80.93_leadership3|leadership3]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Riding a Tougher Dragon (2% Better Resistances; +3% Resist Pierce) &ndash; armour ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
@@ -2005,7 +2007,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the missile attack</span><br/>
 <br/>
-=== Better with Magic Missile &ndash; missile2 ===
+=== Faster with Magic Missile &ndash; missile2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Magic_.E2.80.93_magic|magic]] and [[#Better_with_Magic_Missile_.E2.80.93_missile|missile]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the missile attack</span><br/>
@@ -2013,7 +2015,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Magic Missile &ndash; missile3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Magic_.E2.80.93_magic|magic]] and [[#Better_with_Magic_Missile_.E2.80.93_missile2|missile2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Magic_.E2.80.93_magic|magic]] and [[#Faster_with_Magic_Missile_.E2.80.93_missile2|missile2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the missile attack</span><br/>
 <br/>
 === Better with Fireball &ndash; fireball ===
@@ -2084,14 +2086,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
-=== Better with Crossbow &ndash; xbow2 ===
+=== Faster with Crossbow &ndash; xbow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Crossbow_.E2.80.93_xbow_2|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
 === Better with Crossbow &ndash; xbow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow2_2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_2|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2_2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_2|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
 === Better Protected from Physical Blows (3% Better Resistances) &ndash; armour ===
@@ -2102,8 +2104,8 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Possessing the Leadership of a Level 6 Unit &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 5</span><br/>
-<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership_.E2.80.93_leadership|leadership]]</span><br/>
+<span style='color:#60A0FF'>Remove ability: leadership</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 6 unit)]]</span><br/>
 <br/>
 === Able to Make All Adjacent Allies Capable to Attack First Even when Defending &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -2139,7 +2141,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the berserker frenzy attack</span><br/>
 <br/>
-=== Frenzying Better &ndash; axe2 ===
+=== Frenzying Faster &ndash; axe2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Frenzying_Better_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the berserker frenzy attack</span><br/>
@@ -2147,15 +2149,15 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Frenzying Better &ndash; axe3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Frenzying_Better_.E2.80.93_axe|axe]] and [[#Frenzying_Better_.E2.80.93_axe2|axe2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Frenzying_Better_.E2.80.93_axe|axe]] and [[#Frenzying_Faster_.E2.80.93_axe2|axe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the berserker frenzy attack</span><br/>
 <br/>
 === Frenzying Better &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Frenzying_Better_.E2.80.93_axe|axe]], [[#Frenzying_Better_.E2.80.93_axe2|axe2]] and [[#Frenzying_Better_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Frenzying_Better_.E2.80.93_axe|axe]], [[#Frenzying_Faster_.E2.80.93_axe2|axe2]] and [[#Frenzying_Better_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the berserker frenzy attack</span><br/>
 <br/>
-=== Tougher &ndash; armour ===
+=== Tougher (2-3% Better Resistances) &ndash; armour ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Resistance to blade increased by 3%</span><br/>
 <span style='color:#60A0FF'>Resistance to impact increased by 2%</span><br/>
@@ -2240,7 +2242,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Hatchet_.E2.80.93_hatchet2_2|hatchet2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the hatchet attack</span><br/>
 <br/>
-=== Blocking Better &ndash; block ===
+=== Better at Blocking (Lowering the Chance to be Hit by 2-4%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 4%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 4%</span><br/>
@@ -2256,14 +2258,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 4%</span><br/>
 <br/>
-=== Capable to Use Lightning &ndash; lightning ===
+=== Capable to Use Lightning (New Attack) &ndash; lightning ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New attack: lightning (22 - 2, fire)</span><br/>
 <span style='color:green'>New weapon special for the lightning attack: magical</span><br/>
 <br/>
 === Casting Stronger Lightnings &ndash; lightning2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Capable_to_Use_Lightning_.E2.80.93_lightning|lightning]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Capable_to_Use_Lightning_(New_Attack)_.E2.80.93_lightning|lightning]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 3 for the lightning attack</span><br/>
 <br/>
 === Casting Lightnings Faster &ndash; lightning3 ===
@@ -2307,7 +2309,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Throwing_Javelins_Faster_.E2.80.93_javelin|javelin]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the javelin attack</span><br/>
 <br/>
-=== Able to Charge into Battle &ndash; charge ===
+=== Able to Charge into Battle (New Attack) &ndash; charge ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: charge (100%, 100% melee)</span><br/>
 <span style='color:green'>New weapon special for the charge attack: charge</span><br/>
@@ -2317,7 +2319,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#unyielding_.E2.80.93_resistance|unyielding]]</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#adamant_.E2.80.93_resistance|adamant]]</span><br/>
 <br/>
-=== Blocking Better &ndash; block ===
+=== Better at Blocking (Lowering the Chance to be Hit by 2-4%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 4%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 4%</span><br/>
@@ -2381,37 +2383,37 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Dagger_.E2.80.93_dagger|dagger]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the dagger attack: backstab</span><br/>
 <br/>
-=== More Technically Skilled, Using a Gun that Can Fire Very Quickly &ndash; storm ===
+=== More Technically Skilled, Using a Gun that Can Fire Very Quickly (New Attack) &ndash; storm ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: bullet storm (-90% - 500% ranged)</span><br/>
 <br/>
-=== Shooting Bullet Storms Better &ndash; storm2 ===
+=== Shooting Bullet Storms Faster &ndash; storm2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#More_Technically_Skilled,_Using_a_Gun_that_Can_Fire_Very_Quickly_.E2.80.93_storm|storm]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#More_Technically_Skilled,_Using_a_Gun_that_Can_Fire_Very_Quickly_(New_Attack)_.E2.80.93_storm|storm]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 3% for the bullet storm attack</span><br/>
 <span style='color:green'>100% more attacks for the bullet storm attack</span><br/>
 <br/>
-=== More Technically Skilled, Using a Very Precise Gun &ndash; blunderbuss ===
+=== More Technically Skilled, Using a Very Precise Gun (New Attack) &ndash; blunderbuss ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: blunderbuss (-40% - 100% ranged)</span><br/>
 <span style='color:green'>New weapon special for the blunderbuss attack: marksman</span><br/>
 <br/>
 === Doing More Damage when Shooting Precisely &ndash; blunderbuss2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#More_Technically_Skilled,_Using_a_Very_Precise_Gun_.E2.80.93_blunderbuss|blunderbuss]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#More_Technically_Skilled,_Using_a_Very_Precise_Gun_(New_Attack)_.E2.80.93_blunderbuss|blunderbuss]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 20% for the blunderbuss attack</span><br/>
 <br/>
-=== Shooting Bullets that Penetrate Armour Better &ndash; bullets ===
+=== Shooting Bullets that Penetrate Armour Better (+10% Pierce Resistance Penetration) &ndash; bullets ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Enemy resistances to pierce decreased by 10%</span><br/>
 <br/>
-=== Shooting Bullets that Penetrate Armour Better &ndash; bullets2 ===
+=== Shooting Bullets that Penetrate Armour Better (+5% Pierce Resistance Penetration) &ndash; bullets2 ===
 <span style='color:#808080'><i>This advancement can be taken 4 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Shooting_Bullets_that_Penetrate_Armour_Better_.E2.80.93_bullets|bullets]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Shooting_Bullets_that_Penetrate_Armour_Better_(+10%_Pierce_Resistance_Penetration)_.E2.80.93_bullets|bullets]] to be achieved first</i></span><br/>
 <span style='color:green'>Enemy resistances to pierce decreased by 5%</span><br/>
 <br/>
 === Faster &ndash; movement ===
-<span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
+<span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
 
@@ -2447,20 +2449,20 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Fireball &ndash; fireball3 ===
 <span style='color:#808080'><i>This advancement can be taken 15 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2|fireball2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2_3|fireball2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
-=== Better with Fireball &ndash; fireball3-explosion ===
+=== Dealing Damage to Multiple Enemies with Fireball &ndash; fireball3-explosion ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball3_3|fireball3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the fireball attack: [[LotI_Abilities#explosive_.E2.80.93_damage|explosive]]</span><br/>
-<span style='color:green'>Damage decreased by 7 for the fireball attack</span><br/>
+<span style='color:green'>1 fewer attacks for the fireball attack</span><br/>
 <br/>
 === Better with Lightning &ndash; lightning ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lightning attack</span><br/>
 <br/>
-=== Better with Lightning &ndash; lightning2 ===
+=== Faster with Lightning &ndash; lightning2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Lightning_.E2.80.93_lightning|lightning]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 3 for the lightning attack</span><br/>
@@ -2468,17 +2470,17 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Breaking Through Enemy Arcane Resistances Better (8%) &ndash; arcane-penetrate ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Lightning_.E2.80.93_lightning2|lightning2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Lightning_.E2.80.93_lightning2|lightning2]] to be achieved first</i></span><br/>
 <span style='color:green'>Enemy resistances to arcane decreased by 8%</span><br/>
 <br/>
 === Breaking Through Enemy Arcane Resistances Better (7%) &ndash; arcane-penetrate2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Lightning_.E2.80.93_lightning2|lightning2]] and [[#Breaking_Through_Enemy_Arcane_Resistances_Better_(8%)_.E2.80.93_arcane-penetrate|arcane-penetrate]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Lightning_.E2.80.93_lightning2|lightning2]] and [[#Breaking_Through_Enemy_Arcane_Resistances_Better_(8%)_.E2.80.93_arcane-penetrate|arcane-penetrate]] to be achieved first</i></span><br/>
 <span style='color:green'>Enemy resistances to arcane decreased by 7%</span><br/>
 <br/>
 === Breaking Through Enemy Arcane Resistances Better (5%) &ndash; arcane-penetrate3 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Lightning_.E2.80.93_lightning2|lightning2]] and [[#Breaking_Through_Enemy_Arcane_Resistances_Better_(7%)_.E2.80.93_arcane-penetrate2|arcane-penetrate2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Lightning_.E2.80.93_lightning2|lightning2]] and [[#Breaking_Through_Enemy_Arcane_Resistances_Better_(7%)_.E2.80.93_arcane-penetrate2|arcane-penetrate2]] to be achieved first</i></span><br/>
 <span style='color:green'>Enemy resistances to arcane decreased by 5%</span><br/>
 <br/>
 === Ignoring Enemy Resistances (and Vulnerabilities) with Lightning &ndash; lightning3-lightning ===
@@ -2488,10 +2490,10 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Lightning &ndash; lightning3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Lightning_.E2.80.93_lightning2|lightning2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Lightning_.E2.80.93_lightning2|lightning2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the lightning attack</span><br/>
 <br/>
-=== Capable to Cast Fire Blast &ndash; fireblast1 ===
+=== Capable to Cast Fire Blast (New Attack) &ndash; fireblast1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New attack: fire blast (12 - 3, fire)</span><br/>
 <span style='color:green'>New weapon special for the fire blast attack: magical</span><br/>
@@ -2499,7 +2501,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Casting Fire Blasts Better &ndash; fireblast2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Capable_to_Cast_Fire_Blast_.E2.80.93_fireblast1|fireblast1]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Capable_to_Cast_Fire_Blast_(New_Attack)_.E2.80.93_fireblast1|fireblast1]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the fire blast attack</span><br/>
 <br/>
 === Casting Fire Blasts Faster &ndash; fireblast2_speed ===
@@ -2567,14 +2569,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow|bow]], [[#Better_with_Bow_.E2.80.93_bow2|bow2]] and [[#Faster_with_the_Bow_.E2.80.93_bow3|bow3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the longbow attack</span><br/>
 <br/>
-=== Able to Shoot a Storm of Arrows Without Giving the Enemy a Chance to Counterattack &ndash; arrowstorm ===
+=== Able to Shoot a Storm of Arrows Without Giving the Enemy a Chance to Counterattack (New Attack) &ndash; arrowstorm ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: arrow storm (-20% - -40% ranged, copy of longbow)</span><br/>
 <span style='color:green'>New weapon special for the arrow storm attack: [[LotI_Abilities#distant attack_.E2.80.93_attacks|distant attack]]</span><br/>
 <br/>
 === Shooting Arrow Storms Better &ndash; arrowstorm2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Shoot_a_Storm_of_Arrows_Without_Giving_the_Enemy_a_Chance_to_Counterattack_.E2.80.93_arrowstorm|arrowstorm]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Shoot_a_Storm_of_Arrows_Without_Giving_the_Enemy_a_Chance_to_Counterattack_(New_Attack)_.E2.80.93_arrowstorm|arrowstorm]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the arrow storm attack</span><br/>
 <span style='color:green'>5% more attacks for the arrow storm attack</span><br/>
 <br/>
@@ -2696,45 +2698,45 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_2|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_3|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_3|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_3|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Better with the Bow &ndash; bow ===
+=== Faster with the Bow &ndash; bow ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the bow attack</span><br/>
 <br/>
-=== Better with Bow &ndash; bow2 ===
+=== Better with the Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
-=== Shooting Insanely Precisely &ndash; bow-precise ===
+=== More Precise with Bow &ndash; bow-precise ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]] and [[#Better_with_the_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: marksman</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
 === Better with the Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]] and [[#Better_with_the_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the bow attack</span><br/>
 <br/>
 === Better with the Bow &ndash; bow4 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow|bow]], [[#Better_with_Bow_.E2.80.93_bow2_3|bow2]] and [[#Better_with_the_Bow_.E2.80.93_bow3|bow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]], [[#Better_with_the_Bow_.E2.80.93_bow2|bow2]] and [[#Better_with_the_Bow_.E2.80.93_bow3|bow3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
-=== Able to Attack in a Terribly Scary Way &ndash; horrid ===
+=== Able to Attack in a Terribly Scary Way (New Attack) &ndash; horrid ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: grim strike (-20% - 100% melee)</span><br/>
 <span style='color:green'>New weapon special for the grim strike attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <br/>
 === Scaring Enemies with the Sword Attack Better &ndash; horrid2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terribly_Scary_Way_.E2.80.93_horrid|horrid]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terribly_Scary_Way_(New_Attack)_.E2.80.93_horrid|horrid]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the grim strike attack</span><br/>
 <br/>
-=== Able to Maim Enemies, Lowering Their Damage Until They Advance &ndash; mayhem ===
+=== Able to Maim Enemies, Lowering Their Damage Until They Advance (New Attack) &ndash; mayhem ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Sword_.E2.80.93_sword_3|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>New bonus attack: mayhem (-20% - -40% melee)</span><br/>
@@ -2742,7 +2744,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better when Maiming Enemies &ndash; mayhem2 ===
 <span style='color:#808080'><i>This advancement can be taken 4 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Maim_Enemies,_Lowering_Their_Damage_Until_They_Advance_.E2.80.93_mayhem|mayhem]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Maim_Enemies,_Lowering_Their_Damage_Until_They_Advance_(New_Attack)_.E2.80.93_mayhem|mayhem]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the mayhem attack</span><br/>
 <span style='color:green'>5% more attacks for the mayhem attack</span><br/>
 <br/>
@@ -2801,22 +2803,22 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Faster with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (ranged attacks only)</span><br/>
 <br/>
 === Shooting Very Precisely &ndash; bow-precise ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (ranged attacks only): marksman</span><br/>
 <br/>
 === Faster with the Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]] and [[#Faster_with_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow|bow]] and [[#Faster_with_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (ranged attacks only)</span><br/>
 <br/>
 === Better with the Bow &ndash; bow4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]], [[#Faster_with_Bow_.E2.80.93_bow2|bow2]] and [[#Faster_with_the_Bow_.E2.80.93_bow3_3|bow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow|bow]], [[#Faster_with_Bow_.E2.80.93_bow2|bow2]] and [[#Faster_with_the_Bow_.E2.80.93_bow3_3|bow3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
 === Faster at Melee Combat &ndash; sword ===
@@ -2843,7 +2845,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_2|sword]] and [[#Better_at_Melee_Combat_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): backstab</span><br/>
 <br/>
-=== Able to Enter a Shooting Frenzy Like Dwarves with Axes, But Only when Attacking &ndash; berserk ===
+=== Able to Enter a Shooting Frenzy Like Dwarves with Axes, But Only when Attacking (New Attack) &ndash; berserk ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Bow_.E2.80.93_bow2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New bonus attack: bow_berserk (-30% - 100% ranged, copy of bow)</span><br/>
@@ -2851,12 +2853,12 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Shooting Faster when in Shooting Frenzy &ndash; berserk2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Enter_a_Shooting_Frenzy_Like_Dwarves_with_Axes,_But_Only_when_Attacking_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Enter_a_Shooting_Frenzy_Like_Dwarves_with_Axes,_But_Only_when_Attacking_(New_Attack)_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
 <span style='color:green'>10% more attacks for the bow_berserk attack</span><br/>
 <br/>
 === Shooting Better when in Shooting Frenzy &ndash; berserk2_damage ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Enter_a_Shooting_Frenzy_Like_Dwarves_with_Axes,_But_Only_when_Attacking_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Enter_a_Shooting_Frenzy_Like_Dwarves_with_Axes,_But_Only_when_Attacking_(New_Attack)_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the bow_berserk attack</span><br/>
 <br/>
 === Better at Blocking (Lowering the Chance to be Hit by 2%) &ndash; dodge ===
@@ -2919,7 +2921,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancements [[#A_Faster_Caster_.E2.80.93_faerie|faerie]], [[#A_Better_Caster_.E2.80.93_faerie2|faerie2]] and [[#A_Faster_Caster_.E2.80.93_faerie3|faerie3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
-=== Able to Cover His Sword in Sticky Spiderwebs to Slow Enemies &ndash; gossamer ===
+=== Able to Cover His Sword in Sticky Spiderwebs to Slow Enemies (New Attack) &ndash; gossamer ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Caster_.E2.80.93_faerie2|faerie2]] to be achieved first</i></span><br/>
 <span style='color:green'>New bonus attack: spiderweb sword (-40% - 100% melee)</span><br/>
@@ -2927,7 +2929,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Dealing More Damage with the Spiderweb Sword &ndash; gossamer2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Cover_His_Sword_in_Sticky_Spiderwebs_to_Slow_Enemies_.E2.80.93_gossamer|gossamer]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Cover_His_Sword_in_Sticky_Spiderwebs_to_Slow_Enemies_(New_Attack)_.E2.80.93_gossamer|gossamer]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the spiderweb sword attack</span><br/>
 <br/>
 === Better Protected from Physical Blows (2% Better Resistances) &ndash; armour ===
@@ -2948,13 +2950,13 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Able to Lead Allies into Battle (Like a Level 3 Unit) &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === A Greater Leader in Battle (Like a Proper Level 4 Unit) &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Lead_Allies_into_Battle_(Like_a_Level_3_Unit)_.E2.80.93_leadership|leadership]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 3</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === Better at Blocking (Lowering the Chance to be Hit by 3%) &ndash; dodge ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
@@ -2989,41 +2991,41 @@ This unit also has generic AMLA advancements</i></span>
 Special Notes: This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn. This unit is capable of basic healing. This unit has magical attacks, which always have a high chance of hitting an opponent.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Better at Melee Combat &ndash; melee ===
+=== Faster at Melee Combat &ndash; melee ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the faerie touch attack</span><br/>
 <br/>
 === Better at Melee Combat &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_melee_4|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee_3|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the faerie touch attack</span><br/>
 <br/>
-=== Able to Create a Sword from Pure Magic &ndash; sabre ===
+=== Able to Create a Sword from Pure Magic (New Attack) &ndash; sabre ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: faerie sabre (10% - 20% melee arcane)</span><br/>
 <span style='color:green'>New weapon special for the faerie sabre attack: [[LotI_Abilities#struggle_.E2.80.93_chance_to_hit|struggle]]</span><br/>
 <br/>
 === Doing More Damage with Faerie Sabre &ndash; sabre2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Create_a_Sword_from_Pure_Magic_.E2.80.93_sabre|sabre]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Create_a_Sword_from_Pure_Magic_(New_Attack)_.E2.80.93_sabre|sabre]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the faerie sabre attack</span><br/>
 <br/>
-=== Better with Spiderwebs &ndash; web ===
+=== Faster with Spiderwebs &ndash; web ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the gossamer attack</span><br/>
 <br/>
 === Better with Spiderwebs &ndash; web2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Spiderwebs_.E2.80.93_web|web]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Spiderwebs_.E2.80.93_web|web]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the gossamer attack</span><br/>
 <br/>
-=== Better with Faerie Fire &ndash; magic ===
+=== Faster with Faerie Fire &ndash; magic ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the faerie fire attack</span><br/>
 <br/>
 === Better with Faerie Fire &ndash; magic2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Faerie_Fire_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Faerie_Fire_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the faerie fire attack</span><br/>
 <br/>
 === Decreasing Arcane Resistance to All Adjacent Enemies by 10% &ndash; arcane_penetrate ===
@@ -3046,7 +3048,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: cures</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#heals +VALUE_.E2.80.93_heals|heals (12)]]</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -3079,25 +3081,25 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Melee Combat &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee_2|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_melee_4|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Better with Spiderwebs &ndash; web ===
+=== Faster with Spiderwebs &ndash; web ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the gossamer attack</span><br/>
 <br/>
 === Better with Spiderwebs &ndash; web2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Spiderwebs_.E2.80.93_web_2|web]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Spiderwebs_.E2.80.93_web_2|web]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the gossamer attack</span><br/>
 <br/>
-=== Better with Faerie Fire &ndash; magic ===
+=== Faster with Faerie Fire &ndash; magic ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks (arcane attacks only)</span><br/>
 <br/>
 === Better with Faerie Fire &ndash; magic2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Faerie_Fire_.E2.80.93_magic_2|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Faerie_Fire_.E2.80.93_magic_2|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (arcane attacks only)</span><br/>
 <br/>
 === Better at Defending &ndash; block ===
@@ -3138,7 +3140,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_3|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_4|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_4|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_4|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Faster with the Bow &ndash; bow ===
@@ -3148,43 +3150,43 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_the_Bow_.E2.80.93_bow_4|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
 === Shooting Very Precisely &ndash; bow-precise ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_4|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_4|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: marksman</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
 === Faster with the Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_4|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_4|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the bow attack</span><br/>
 <br/>
 === Better with the Bow &ndash; bow4 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_3|bow]], [[#Better_with_Bow_.E2.80.93_bow2_4|bow2]] and [[#Faster_with_the_Bow_.E2.80.93_bow3_4|bow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_the_Bow_.E2.80.93_bow_4|bow]], [[#Better_with_Bow_.E2.80.93_bow2_3|bow2]] and [[#Faster_with_the_Bow_.E2.80.93_bow3_4|bow3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
 === A Better Leader (Like a Level 5 Unit) &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: leadership</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Able to Improve Nearby Allies' Reactions &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Leader_(Like_a_Level_5_Unit)_.E2.80.93_leadership|leadership]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#zeal aura_.E2.80.93_dummy|zeal aura]]</span><br/>
 <br/>
-=== Able to Attack in a Terribly Scary Way &ndash; horrid ===
+=== Able to Attack in a Terribly Scary Way (New Attack) &ndash; horrid ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: grim strike (-20% - 100% melee)</span><br/>
 <span style='color:green'>New weapon special for the grim strike attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <br/>
 === Scaring Enemies with the Sword Attack Better &ndash; horrid2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terribly_Scary_Way_.E2.80.93_horrid_2|horrid]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terribly_Scary_Way_(New_Attack)_.E2.80.93_horrid_2|horrid]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the grim strike attack</span><br/>
 <br/>
 === Better at Blocking (Lowering the Chance to be Hit by 2%) &ndash; dodge ===
@@ -3240,7 +3242,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the scythe attack</span><br/>
 <br/>
-=== Better with Scythe &ndash; scythe2 ===
+=== Faster with Scythe &ndash; scythe2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Scythe_.E2.80.93_scythe|scythe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 3 for the scythe attack</span><br/>
@@ -3248,14 +3250,14 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Scythe &ndash; scythe3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Scythe_.E2.80.93_scythe2|scythe2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Scythe_.E2.80.93_scythe2|scythe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the scythe attack</span><br/>
 <br/>
 === Faster with Knives &ndash; knife ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
 <span style='color:green'>1 more attacks for the knife attack</span><br/>
 <br/>
-=== Very Precise with Knives &ndash; knife2 ===
+=== Insanely Precise with Knives &ndash; knife2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Knives_.E2.80.93_knife|knife]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the knife attack: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
@@ -3263,20 +3265,20 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Knives &ndash; knife3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Knives_.E2.80.93_knife|knife]] and [[#Very_Precise_with_Knives_.E2.80.93_knife2|knife2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Knives_.E2.80.93_knife|knife]] and [[#Insanely_Precise_with_Knives_.E2.80.93_knife2|knife2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the knife attack</span><br/>
 <br/>
-=== Able to Charge at Enemies when Backstabbing if Selected &ndash; murderous_frenzy ===
+=== Able to Charge at Enemies when Backstabbing if Selected (New Attack) &ndash; murderous_frenzy ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: murderous frenzy (-30% - 100% melee, copy of dagger)</span><br/>
 <span style='color:green'>New weapon special for the murderous frenzy attack: [[LotI_Abilities#charging backstab_.E2.80.93_damage|charging backstab]]</span><br/>
 <br/>
 === Charging at Enemy Backs Better &ndash; murderous_frenzy2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Charge_at_Enemies_when_Backstabbing_if_Selected_.E2.80.93_murderous_frenzy|murderous_frenzy]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Charge_at_Enemies_when_Backstabbing_if_Selected_(New_Attack)_.E2.80.93_murderous_frenzy|murderous_frenzy]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the murderous frenzy attack</span><br/>
 <br/>
-=== Able to Perform a Whirlwind Attack &ndash; whirlwind ===
+=== Able to Perform a Whirlwind Attack (New Attack) &ndash; whirlwind ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: whirlwind-scythe (-30% - -30% melee, copy of scythe)</span><br/>
 <span style='color:green'>New weapon special for the whirlwind-scythe attack: [[LotI_Abilities#whirlwind_.E2.80.93_attacks|whirlwind]]</span><br/>
@@ -3284,7 +3286,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Whirling Better &ndash; whirlwind2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Perform_a_Whirlwind_Attack_.E2.80.93_whirlwind|whirlwind]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Perform_a_Whirlwind_Attack_(New_Attack)_.E2.80.93_whirlwind|whirlwind]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the whirlwind-scythe attack</span><br/>
 <br/>
 === Able to Move at Night Without Being Seen on Useful Terrains &ndash; nightstalk ===
@@ -3297,7 +3299,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
 <span style='color:#60A0FF'>New ability: nightstalk</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 3%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 3%</span><br/>
@@ -3313,9 +3315,9 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 3%</span><br/>
 <br/>
-=== Better at Defending &ndash; block2 ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_4|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_2|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 2%</span><br/>
@@ -3330,9 +3332,9 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 2%</span><br/>
 <br/>
-=== Better at Defending &ndash; block3 ===
+=== Better at Defending (Lowering the Chance to be Hit by 1%) &ndash; block3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_.E2.80.93_block_4|block]] and [[#Better_at_Defending_.E2.80.93_block2|block2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_2|block]] and [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_2%)_.E2.80.93_block2|block2]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 1%</span><br/>
@@ -3357,22 +3359,22 @@ This unit also has generic AMLA advancements</i></span>
 Special Notes: This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn. This unit is capable of healing those around it, and curing them of poison. This unit has magical attacks, which always have a high chance of hitting an opponent. During battle, this unit can drain life from victims to renew its own health. The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures. This unit regenerates, which allows it to heal as though always stationed in a village, if it is standing in a forest.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Commanding Vines Better &ndash; melee ===
+=== Commanding Vines to Attack Faster &ndash; melee ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Commanding Vines Better &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken 4 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Commanding_Vines_Better_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Commanding_Vines_to_Attack_Faster_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Ensnaring Better &ndash; ensnare ===
+=== Ensnaring Faster &ndash; ensnare ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the ensnare attack</span><br/>
 <br/>
 === Ensnaring Better &ndash; ensnare2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Ensnaring_Better_.E2.80.93_ensnare|ensnare]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Ensnaring_Faster_.E2.80.93_ensnare|ensnare]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the ensnare attack</span><br/>
 <br/>
 === Piercing with Thorns Better &ndash; thorns ===
@@ -3453,7 +3455,7 @@ Special Notes: This unit’s skill at skirmishing allows it to ignore enemies’
 <span style='color:green'>Damage increased by 1 (arcane attacks only)</span><br/>
 <span style='color:green'>1 more attacks (arcane attacks only)</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Much Better at Defending &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests increased by 25%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places increased by 40%</span><br/>
@@ -3484,7 +3486,7 @@ Special Notes: This unit’s skill at skirmishing allows it to ignore enemies’
 <span style='color:green'>Damage increased by 1 (arcane attacks only)</span><br/>
 <span style='color:green'>1 more attacks (arcane attacks only)</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Much Better at Defending &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests increased by 25%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places increased by 40%</span><br/>
@@ -3512,9 +3514,9 @@ Special Notes: This unit’s skill at skirmishing allows it to ignore enemies’
 <span style='color:green'>Damage increased by 1 (arcane attacks only)</span><br/>
 <span style='color:green'>1 more attacks (arcane attacks only)</span><br/>
 <br/>
-=== Better at Defending &ndash; block2 ===
+=== Ridiculously Good at Defending &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_7|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Much_Better_at_Defending_.E2.80.93_block_3|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests increased by 20%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places increased by 30%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains increased by 20%</span><br/>
@@ -3550,7 +3552,7 @@ Special Notes: This unit’s skill at skirmishing allows it to ignore enemies’
 <span style='color:green'>Damage increased by 3 (arcane attacks only)</span><br/>
 <span style='color:green'>1 more attacks (arcane attacks only)</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Much Better at Defending &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests increased by 25%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places increased by 40%</span><br/>
@@ -3584,9 +3586,9 @@ Special Notes: This unit’s skill at skirmishing allows it to ignore enemies’
 <span style='color:green'>Damage increased by 3 (arcane attacks only)</span><br/>
 <span style='color:green'>1 more attacks (arcane attacks only)</span><br/>
 <br/>
-=== Better at Defending &ndash; block2 ===
+=== Ridiculously Good at Defending &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_7|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Much_Better_at_Defending_.E2.80.93_block_3|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests increased by 20%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places increased by 30%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains increased by 20%</span><br/>
@@ -3634,7 +3636,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
-=== Striking Better with Bow &ndash; bow2 ===
+=== Striking Faster with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow_2|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
@@ -3642,12 +3644,12 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2_2|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2_2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
 === Shooting Insanely Precisely &ndash; bow-precise ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Bow_.E2.80.93_bow_2|bow]], [[#Striking_Better_with_Bow_.E2.80.93_bow2_2|bow2]] and [[#Striking_Better_with_Bow_.E2.80.93_bow3_2|bow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Bow_.E2.80.93_bow_2|bow]], [[#Striking_Faster_with_Bow_.E2.80.93_bow2_2|bow2]] and [[#Striking_Better_with_Bow_.E2.80.93_bow3_2|bow3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
 <span style='color:green'>Remove weapon special for the bow attack: marksman</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
@@ -3656,7 +3658,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Striking Better with Sword &ndash; sword2 ===
+=== Striking Faster with Sword &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Sword_.E2.80.93_sword_5|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the sword attack</span><br/>
@@ -3664,17 +3666,17 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Sword_.E2.80.93_sword2_2|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Sword_.E2.80.93_sword2_5|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Able to Attack Parrying Enemy Blows &ndash; parry ===
+=== Able to Attack Parrying Enemy Blows (New Attack) &ndash; parry ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: parry (-20% - -70% melee)</span><br/>
 <span style='color:green'>New weapon special for the parry attack: [[LotI_Abilities#parry_.E2.80.93_dummy|parry]]</span><br/>
 <br/>
 === Parrying Better &ndash; parry2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_.E2.80.93_parry|parry]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_(New_Attack)_.E2.80.93_parry|parry]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the parry attack</span><br/>
 <span style='color:green'>5% more attacks for the parry attack</span><br/>
 <br/>
@@ -3684,7 +3686,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Resistance to impact increased by 1%</span><br/>
 <span style='color:#60A0FF'>Resistance to pierce increased by 2%</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -3820,8 +3822,8 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === A Better Leader &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 2</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>Remove ability: leadership</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === Better at Dodging Enemy Attacks (Lowering the Chance to be Hit by 2%) &ndash; dodge ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
@@ -3854,7 +3856,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
-=== Striking Better with Lance &ndash; lance2 ===
+=== Striking Faster with Lance &ndash; lance2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 3 for the lance attack</span><br/>
@@ -3862,22 +3864,22 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Charging More Powerfully with Lance (2.5 Times More Damage) &ndash; lance3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]] and [[#Striking_Better_with_Lance_.E2.80.93_lance2_2|lance2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]] and [[#Striking_Faster_with_Lance_.E2.80.93_lance2_2|lance2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (2.5)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Charging Even More Powerfully with the Lance (3 Times More Damage) &ndash; lance4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]], [[#Striking_Better_with_Lance_.E2.80.93_lance2_2|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_2|lance3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]], [[#Striking_Faster_with_Lance_.E2.80.93_lance2_2|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_2|lance3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (3)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Striking Even Better with the Lance &ndash; lance5 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]], [[#Striking_Better_with_Lance_.E2.80.93_lance2_2|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_2|lance3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_2|lance]], [[#Striking_Faster_with_Lance_.E2.80.93_lance2_2|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_2|lance3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
-=== Able to Knock Enemies Back &ndash; knockback ===
+=== Able to Knock Enemies Back (New Attack) &ndash; knockback ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: knockback (100%, 100% melee, copy of lance)</span><br/>
 <span style='color:green'>New weapon special for the knockback attack: [[LotI_Abilities#knockback_.E2.80.93_damage|knockback]]</span><br/>
@@ -3888,18 +3890,18 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Axe Combat &ndash; axe2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe_2|axe]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the axe attack</span><br/>
 <br/>
-=== Better at Axe Combat &ndash; axe3 ===
+=== Faster at Axe Combat &ndash; axe3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_2|axe]] and [[#Better_at_Axe_Combat_.E2.80.93_axe2|axe2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe|axe]] and [[#Better_at_Axe_Combat_.E2.80.93_axe2|axe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the axe attack</span><br/>
 <span style='color:green'>1 more attacks for the axe attack</span><br/>
 <br/>
 === Better at Axe Combat &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_2|axe]], [[#Better_at_Axe_Combat_.E2.80.93_axe2|axe2]] and [[#Better_at_Axe_Combat_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe|axe]], [[#Better_at_Axe_Combat_.E2.80.93_axe2|axe2]] and [[#Faster_at_Axe_Combat_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the axe attack</span><br/>
 <br/>
 === More Undead-Like Resistance (Improved Resistances, Slightly Worsened Weaknesses) &ndash; armour ===
@@ -3918,7 +3920,7 @@ This unit also has generic AMLA advancements</i></span>
 
 == Half-Robotic Freak (Akula Steel Finale) ==
 <span style='color:#808080'><i>She was once a normal person. Until she found some forgotten ruins with weapons of great technical level, and manipulating with one of them transformed her into this. She survived it only thanks to necromancy, but now she is a whole new level freak.<br/>
-Special notes: When this unit is attacked in melee range, the attacker takes a huge amount of impact damage from her tentacles, because he strayed to close. This unit will regenerate, as if she was standing in a village all the time. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit has magical attacks, which always have a high chance of hitting an opponent.</i></span>
+Special Notes: When this unit is attacked in melee range, the attacker takes a huge amount of impact damage from her tentacles, because he strayed too close. This unit regenerates, which allows it to heal as though always stationed in a village. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit has magical attacks, which always have a high chance of hitting an opponent.</i></span>
 
 === Better at Melee Combat &ndash; sword ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -3960,7 +3962,7 @@ Special notes: When this unit is attacked in melee range, the attacker takes a h
 
 == Half-Robotic Freak (Akula Steel) ==
 <span style='color:#808080'><i>She was once a normal person. Until she found some forgotten ruins with weapons of great technical level, and manipulating with one of them transformed her into this. She survived it only thanks to necromancy, but now she is a whole new level freak.<br/>
-Special notes: When this unit is attacked in melee range, the attacker takes 15 impact damage from her tentacles, because he strayed to close. This unit will regenerate, as if she was standing in a village all the time. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit has magical attacks, which always have a high chance of hitting an opponent.</i></span>
+Special Notes: When this unit is attacked in melee range, the attacker takes 15 impact damage from her tentacles, because he strayed too close. This unit regenerates, which allows it to heal as though always stationed in a village. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit has magical attacks, which always have a high chance of hitting an opponent.</i></span>
 
 === Better at Melee Combat &ndash; sword ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -4001,13 +4003,13 @@ Special notes: When this unit is attacked in melee range, the attacker takes 15 
 <br/>
 
 == Infernal Knight ==
-<span style='color:#808080'><i>Tales are told of the mightiest warriors and generals, who, cursed with hate and stung by betrayal, have experimented with demonic magic and returned back to this world as Death Knights. Wielding the same weapons as in life, they command both fire and the Undead in their quest for revenge.<br/>
+<span style='color:#808080'><i>Tales are told of the mightiest warriors and generals, who, cursed with hate and stung by betrayal, have experimented with demonic magic and returned back to this world as Infernal Knights. Wielding the same weapons as in life, they command both fire and the Undead in their quest for revenge.<br/>
 Special Notes: The leadership of this unit enables adjacent units of the same side to deal more damage in combat, though this only applies to units of lower level. This unit has magical attacks, which always have a high chance of hitting an opponent.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Casting Fireballs when Attacking &ndash; firecast ===
+=== Casting Random Fire Spells on Enemies when Attacking Them with an Axe &ndash; firecast ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Fireball_.E2.80.93_fireball_5|fireball]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Fireball_.E2.80.93_fireball_5|fireball]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3_2|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#firecast_.E2.80.93_dummy|firecast]]</span><br/>
 <br/>
@@ -4028,7 +4030,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Melee Combat &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe_2|axe]], [[#Better_at_Melee_Combat_.E2.80.93_axe2_2|axe2]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe_2|axe]], [[#Better_at_Melee_Combat_.E2.80.93_axe2_2|axe2]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3_2|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === Better with Fireball &ndash; fireball ===
@@ -4043,19 +4045,19 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Fireball &ndash; fireball3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2_2|fireball2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2_4|fireball2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
-=== Better with Fireball &ndash; fireball3-explosion ===
+=== Dealing Damage to Multiple Enemies with Fireball &ndash; fireball3-explosion ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball3_4|fireball3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the fireball attack: [[LotI_Abilities#explosive_.E2.80.93_damage|explosive]]</span><br/>
-<span style='color:green'>Damage decreased by 7 for the fireball attack</span><br/>
+<span style='color:green'>1 fewer attacks for the fireball attack</span><br/>
 <br/>
 === A Greater Leader in Battle (Like a Level 5 Unit) &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: leadership</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === 10% More Resistant to Fire &ndash; fire_resist ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
@@ -4259,19 +4261,19 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Possessing the Leadership of a Level 3 Unit &ndash; leadership1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === Possessing the Leadership of a Level 4 Unit &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Possessing_the_Leadership_of_a_Level_3_Unit_.E2.80.93_leadership1|leadership1]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 3</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === Possessing the Leadership of a Level 5 Unit &ndash; leadership3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Possessing_the_Leadership_of_a_Level_4_Unit_.E2.80.93_leadership2|leadership2]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Able to Heal Allies Better &ndash; heal ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -4301,7 +4303,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#frail tide (INTENSITY)_.E2.80.93_resistance|frail tide (20)]]</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#frail tide (INTENSITY)_.E2.80.93_resistance|frail tide (25)]]</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -4515,19 +4517,19 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Possessing the Leadership of a Level 3 Unit &ndash; leadership1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === Possessing the Leadership of a Level 4 Unit &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Possessing_the_Leadership_of_a_Level_3_Unit_.E2.80.93_leadership1_2|leadership1]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 3</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === Possessing the Leadership of a Level 5 Unit &ndash; leadership3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Possessing_the_Leadership_of_a_Level_4_Unit_.E2.80.93_leadership2_2|leadership2]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Able to Heal Allies Better &ndash; heal ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -4546,7 +4548,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#heals +VALUE_.E2.80.93_heals|heals (18)]]</span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#heals +VALUE_.E2.80.93_heals|heals (24)]]</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -4589,17 +4591,17 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Melee Combat &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe_3|axe]], [[#Better_at_Melee_Combat_.E2.80.93_axe2_3|axe2]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3_2|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_axe_3|axe]], [[#Better_at_Melee_Combat_.E2.80.93_axe2_3|axe2]] and [[#Faster_at_Melee_Combat_.E2.80.93_axe3_3|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Able to Attack in a Terrible Way that Lowers Enemy Resistance &ndash; doom ===
+=== Able to Attack in a Terrible Way that Lowers Enemy Resistance (New Attack) &ndash; doom ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: doom (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the doom attack: [[LotI_Abilities#doom_.E2.80.93_dummy|doom]]</span><br/>
 <br/>
 === Crippling Enemies Better &ndash; doom2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_.E2.80.93_doom_2|doom]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_(New_Attack)_.E2.80.93_doom_2|doom]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the doom attack</span><br/>
 <span style='color:green'>5% more attacks for the doom attack</span><br/>
 <br/>
@@ -4628,8 +4630,8 @@ This unit also has generic AMLA advancements</i></span>
 === A Greater Leader in Battle (Like a Level 5 Unit) &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_axe_3|axe]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 4</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 5</span><br/>
+<span style='color:#60A0FF'>Remove ability: leadership</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 5 unit)]]</span><br/>
 <br/>
 === Faster &ndash; movement ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
@@ -4638,7 +4640,7 @@ This unit also has generic AMLA advancements</i></span>
 
 == Lord of the Flies (Beelzebub) ==
 <span style='color:#808080'><i>Ancient nobles of demonkind are among the scariest visitors from Inferno. Their vast power and number of followers allow them to destroy armies, bringing death and destruction whenever they come. Fortunately for mankind, they live in Inferno and rarely get out of there. However, some of them have made spells to summon them are known and sometimes come into the hands of the foolish...<br/>
-Special Notes: This unit regenerates, which allows it to heal as though always stationed in a village. This unit can move unseen in deep water, requiring no air from the surface. The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures. This unit has magical attacks, which always have a high chance of hitting an opponent. During battle, this unit can drain life from victims to renew its own health.</i></span>
+Special Notes: This unit regenerates, which allows it to heal as though always stationed in a village. This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures. This unit can move unseen in deep water, requiring no air from the surface. The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures. This unit has magical attacks, which always have a high chance of hitting an opponent. During battle, this unit can drain life from victims to renew its own health.</i></span>
 
 ===  &ndash; amla_demon_lord ===
 <span style='color:#808080'><i>This advancement can be taken 100 times</i></span><br/>
@@ -4655,7 +4657,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the lance attack</span><br/>
 <br/>
-=== Striking Better with Lance &ndash; lance2 ===
+=== Striking Faster with Lance &ndash; lance2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 3 for the lance attack</span><br/>
@@ -4663,19 +4665,19 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Charging More Powerfully with Lance (2.5 Times More Damage) &ndash; lance3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]] and [[#Striking_Better_with_Lance_.E2.80.93_lance2_3|lance2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]] and [[#Striking_Faster_with_Lance_.E2.80.93_lance2_3|lance2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (2.5)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Charging Even More Powerfully with the Lance (3 Times More Damage) &ndash; lance4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]], [[#Striking_Better_with_Lance_.E2.80.93_lance2_3|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_3|lance3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]], [[#Striking_Faster_with_Lance_.E2.80.93_lance2_3|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_3|lance3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (3)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Striking Even Better with the Lance &ndash; lance5 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]] and [[#Striking_Better_with_Lance_.E2.80.93_lance2_3|lance2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_3|lance]] and [[#Striking_Faster_with_Lance_.E2.80.93_lance2_3|lance2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
 === Able to Move One Hex After Attacking an Enemy &ndash; penetrate ===
@@ -4790,8 +4792,8 @@ This unit also has generic AMLA advancements</i></span>
 === Kicking Faster &ndash; kick2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Kicking_Better_.E2.80.93_kick|kick]] to be achieved first</i></span><br/>
-<span style='color:green'>Damage decreased by 1 for the kcik attack</span><br/>
-<span style='color:green'>1 more attacks for the kcik attack</span><br/>
+<span style='color:green'>Damage decreased by 1 for the kick attack</span><br/>
+<span style='color:green'>1 more attacks for the kick attack</span><br/>
 <br/>
 === Throwing Enemies Back with Kicks &ndash; kick3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -4846,7 +4848,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
 <span style='color:#60A0FF'>New ability: nightstalk</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 3%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 3%</span><br/>
@@ -4864,7 +4866,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Defending &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_11|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_3|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 2%</span><br/>
@@ -4881,7 +4883,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Defending &ndash; block3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_.E2.80.93_block_11|block]] and [[#Better_at_Defending_.E2.80.93_block2_4|block2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_3|block]] and [[#Better_at_Defending_.E2.80.93_block2|block2]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 1%</span><br/>
@@ -4922,23 +4924,23 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Faster with Crossbow &ndash; xbow3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_3|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_3|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the crossbow attack</span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
 === Shooting More Precisely &ndash; xbow-marksman ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Faster_with_Crossbow_.E2.80.93_xbow3|xbow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] and [[#Faster_with_Crossbow_.E2.80.93_xbow3|xbow3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the crossbow attack: marksman</span><br/>
 <br/>
 === Incinerating Enemies with Fiery Shots &ndash; xbow-incinerate ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_3|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_3|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the crossbow attack (fire attacks only): [[LotI_Abilities#incinerate_.E2.80.93_dummy|incinerate]]</span><br/>
 <br/>
 === Better with Crossbow &ndash; xbow4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_3|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow_3|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
 === Shooting so Hard that Enemies Behind Targets Will be Hit as Well &ndash; xbow-pierce ===
@@ -4983,24 +4985,24 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Attacking in a Scary Way &ndash; sword2-horror ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Sword_.E2.80.93_sword_7|sword]] and [[#Striking_Faster_with_Sword_.E2.80.93_sword2_5|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Sword_.E2.80.93_sword_7|sword]] and [[#Striking_Faster_with_Sword_.E2.80.93_sword2_7|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the greatsword attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <span style='color:green'>Remove weapon special for the greatsword attack: horrid,horrid_dummy</span><br/>
 <span style='color:green'>Damage decreased by 1 for the greatsword attack</span><br/>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_5|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_7|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_7|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_7|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the greatsword attack</span><br/>
 <br/>
-=== Able to Attack in a Terrible Way that Lowers Enemy Resistance &ndash; doom ===
+=== Able to Attack in a Terrible Way that Lowers Enemy Resistance (New Attack) &ndash; doom ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: doom (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the doom attack: [[LotI_Abilities#doom_.E2.80.93_dummy|doom]]</span><br/>
 <br/>
 === Crippling Enemies Better &ndash; doom2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_.E2.80.93_doom_3|doom]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_(New_Attack)_.E2.80.93_doom_3|doom]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the doom attack</span><br/>
 <span style='color:green'>5% more attacks for the doom attack</span><br/>
 <br/>
@@ -5008,36 +5010,36 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
-=== Better with Bow &ndash; bow2 ===
+=== Faster with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the bow attack</span><br/>
 <br/>
 === Shooting Poisonous Arrows &ndash; bow-poison ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Bow_.E2.80.93_bow2_5|bow2]] and [[#Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Bow_.E2.80.93_bow2_2|bow2]] and [[#Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: poison</span><br/>
 <br/>
 === Better with Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Bow_.E2.80.93_bow2_5|bow2]] and [[#Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Bow_.E2.80.93_bow2_2|bow2]] and [[#Better_with_Bow_.E2.80.93_bow|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
 === Able to Lead Allies into Battle (Like a Level 2 Unit) &ndash; leadership ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 2</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 2 unit)]]</span><br/>
 <br/>
 === A Better Leader (Like a Level 3 Unit) &ndash; leadership2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Lead_Allies_into_Battle_(Like_a_Level_2_Unit)_.E2.80.93_leadership_2|leadership]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 2</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 3</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 2 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
 <br/>
 === A Better Leader (Like a Level 4 Unit) &ndash; leadership3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Leader_(Like_a_Level_3_Unit)_.E2.80.93_leadership2|leadership2]] to be achieved first</i></span><br/>
-<span style='color:#60A0FF'>Remove ability: leadership level 3</span><br/>
-<span style='color:#60A0FF'>New ability: leadership level 4</span><br/>
+<span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 3 unit)]]</span><br/>
+<span style='color:#60A0FF'>New ability: [[LotI_Abilities#leadership (as level LEVEL unit)_.E2.80.93_leadership|leadership (as level 4 unit)]]</span><br/>
 <br/>
 === Able to Cause Nearby Allies to Attack Like Bloodthirsty Fanatics &ndash; leadership2_bloodthirst ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -5071,12 +5073,6 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>1 more movement points</span><br/>
 <br/>
 
-== Other Data Loader ==
-<span style='color:#808080'><i></i></span>
-
-===  &ndash;  ===
-<br/>
-
 == Phantom ==
 <span style='color:#808080'><i>Undead lords sometimes figure out a way to make their deathblades fully use their potiential. They remove their legs, replacing them with a ghostly tail allowing them to float and spin as they want. They also add them an additional pair of arms, to make these minions more destructive. Phantoms are, however, quite vulnerable.<br/>
 Special Notes: This unit can move unseen in deep water, requiring no air from the surface.<br/>
@@ -5088,21 +5084,21 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Axe Combat &ndash; axe2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe_3|axe]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe_2|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the axe attack</span><br/>
 <br/>
-=== Better at Axe Combat &ndash; axe3 ===
+=== Faster at Axe Combat &ndash; axe3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_3|axe]] and [[#Better_at_Axe_Combat_.E2.80.93_axe2_2|axe2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_2|axe]] and [[#Better_at_Axe_Combat_.E2.80.93_axe2_2|axe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the axe attack</span><br/>
 <span style='color:green'>1 more attacks for the axe attack</span><br/>
 <br/>
 === Better at Axe Combat &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_3|axe]], [[#Better_at_Axe_Combat_.E2.80.93_axe2_2|axe2]] and [[#Better_at_Axe_Combat_.E2.80.93_axe3_2|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_2|axe]], [[#Better_at_Axe_Combat_.E2.80.93_axe2_2|axe2]] and [[#Faster_at_Axe_Combat_.E2.80.93_axe3_2|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the axe attack</span><br/>
 <br/>
-=== Able to Perform a Whirlwind Attack &ndash; whirlwind ===
+=== Able to Perform a Whirlwind Attack (New Attack) &ndash; whirlwind ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: whirlwind-axe (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the whirlwind-axe attack: [[LotI_Abilities#whirlwind_.E2.80.93_attacks|whirlwind]]</span><br/>
@@ -5110,7 +5106,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Whirling Better &ndash; whirlwind2 ===
 <span style='color:#808080'><i>This advancement can be taken 4 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Perform_a_Whirlwind_Attack_.E2.80.93_whirlwind_2|whirlwind]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Perform_a_Whirlwind_Attack_(New_Attack)_.E2.80.93_whirlwind_2|whirlwind]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the whirlwind-axe attack</span><br/>
 <br/>
 === More Nimble (Lowering the Chance to be Hit by 4%) &ndash; dodge ===
@@ -5170,18 +5166,18 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Throwing_Pilums_Better_.E2.80.93_javelin2|javelin2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the javelin attack: marksman</span><br/>
 <br/>
-=== Able to Attack in a Tricky Way that Lowers Enemy Defence &ndash; trickery ===
+=== Able to Attack in a Tricky Way that Lowers Enemy Defence (New Attack) &ndash; trickery ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: trickery (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the trickery attack: [[LotI_Abilities#trickery_.E2.80.93_dummy|trickery]]</span><br/>
 <br/>
 === Tricking Enemies Better &ndash; trickery2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Tricky_Way_that_Lowers_Enemy_Defence_.E2.80.93_trickery|trickery]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Tricky_Way_that_Lowers_Enemy_Defence_(New_Attack)_.E2.80.93_trickery|trickery]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the trickery attack</span><br/>
 <span style='color:green'>10% more attacks for the trickery attack</span><br/>
 <br/>
-=== Blocking Better &ndash; block ===
+=== Better at Blocking (Lowering the Chance to be Hit by 2-3%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 3%</span><br/>
@@ -5218,7 +5214,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>Remove weapon special for the bow attack: marksman</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
-=== Striking Better with Bow &ndash; bow2 ===
+=== Striking Faster with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow_3|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
@@ -5226,46 +5222,46 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the bow attack</span><br/>
 <br/>
 === Shooting Unbelievably Precisely &ndash; bow-precise2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Bow_.E2.80.93_bow_3|bow]], [[#Striking_Better_with_Bow_.E2.80.93_bow2_3|bow2]], [[#Striking_Better_with_Bow_.E2.80.93_bow3_3|bow3]] and [[#Shooting_Insanely_Precisely_.E2.80.93_bow-precise_4|bow-precise]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Bow_.E2.80.93_bow_3|bow]], [[#Striking_Faster_with_Bow_.E2.80.93_bow2_3|bow2]], [[#Striking_Better_with_Bow_.E2.80.93_bow3_3|bow3]] and [[#Shooting_Insanely_Precisely_.E2.80.93_bow-precise_3|bow-precise]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#guided_.E2.80.93_chance_to_hit|guided]]</span><br/>
 <span style='color:green'>Remove weapon special for the bow attack: focused</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
-=== Able to Deal Heavy Damage with a Single Shot &ndash; execution ===
+=== Able to Deal Heavy Damage with a Single Shot (New Attack) &ndash; execution ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: execution (-45% - 100% ranged)</span><br/>
 <br/>
 === Executing Enemy Bosses Better &ndash; execution2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Deal_Heavy_Damage_with_a_Single_Shot_.E2.80.93_execution|execution]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Deal_Heavy_Damage_with_a_Single_Shot_(New_Attack)_.E2.80.93_execution|execution]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the execution attack</span><br/>
 <br/>
 === Very Good at Slaying Humans &ndash; bow-hunting-humans ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#misanthropia_.E2.80.93_damage|misanthropia]]</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
 === Very Good at Slaying Orcs &ndash; bow-hunting-orcs ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#misorcia_.E2.80.93_damage|misorcia]]</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
 === Very Good at Slaying Elves &ndash; bow-hunting-elves ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#misdryadia_.E2.80.93_damage|misdryadia]]</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
 === Very Good at Slaying Dragons &ndash; bow-hunting-drakes ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the bow attack: [[LotI_Abilities#misdraconia_.E2.80.93_damage|misdraconia]]</span><br/>
 <span style='color:green'>Damage decreased by 1 for the bow attack</span><br/>
 <br/>
@@ -5273,7 +5269,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the dagger attack</span><br/>
 <br/>
-=== Striking Better with Dagger &ndash; dagger2 ===
+=== Striking Faster with Dagger &ndash; dagger2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Dagger_.E2.80.93_dagger|dagger]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the dagger attack</span><br/>
@@ -5281,10 +5277,10 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Dagger &ndash; dagger3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Dagger_.E2.80.93_dagger2|dagger2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Dagger_.E2.80.93_dagger2|dagger2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the dagger attack</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -5363,45 +5359,45 @@ This unit also has soul eater AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_4|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_7|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_5|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_5|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_4|sword5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lichsword attack</span><br/>
 <br/>
-=== Better with Crossbow &ndash; xbow ===
+=== Better and Faster with Crossbow &ndash; xbow ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
 === Striking More Precisely with the Crossbow &ndash; xbow_marksman ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the crossbow attack: marksman</span><br/>
 <br/>
 === Better with Crossbow &ndash; xbow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
 === Faster with Crossbow &ndash; xbow2_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]] and [[#Better_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]] and [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
 === Better with Crossbow &ndash; xbow3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]] and [[#Better_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]] and [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
 === Striking More Precisely with the Crossbow &ndash; xbow-marksman ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]], [[#Better_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] and [[#Striking_More_Precisely_with_the_Crossbow_.E2.80.93_xbow_marksman|xbow_marksman]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]], [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Striking_More_Precisely_with_the_Crossbow_.E2.80.93_xbow_marksman|xbow_marksman]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the crossbow attack: [[LotI_Abilities#focused_.E2.80.93_chance_to_hit|focused]]</span><br/>
 <span style='color:green'>Remove weapon special for the crossbow attack: marksman</span><br/>
 <br/>
 === Better with Crossbow &ndash; xbow4 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]], [[#Better_with_Crossbow_.E2.80.93_xbow2_3|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow3_3|xbow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]], [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]] and [[#Better_with_Crossbow_.E2.80.93_xbow3_3|xbow3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the crossbow attack</span><br/>
 <br/>
 === Faster with Crossbow &ndash; xbow2_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Crossbow_.E2.80.93_xbow_4|xbow]], [[#Better_with_Crossbow_.E2.80.93_xbow2_3|xbow2]], [[#Faster_with_Crossbow_.E2.80.93_xbow2_speed_2|xbow2_speed]], [[#Better_with_Crossbow_.E2.80.93_xbow3_3|xbow3]] and [[#Better_with_Crossbow_.E2.80.93_xbow4_2|xbow4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Crossbow_.E2.80.93_xbow|xbow]], [[#Better_with_Crossbow_.E2.80.93_xbow2|xbow2]], [[#Faster_with_Crossbow_.E2.80.93_xbow2_speed_2|xbow2_speed]], [[#Better_with_Crossbow_.E2.80.93_xbow3_3|xbow3]] and [[#Better_with_Crossbow_.E2.80.93_xbow4_2|xbow4]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
 === Blocking Attacks Better (2 % Better Defence) &ndash; block ===
@@ -5453,7 +5449,7 @@ This unit also has soul eater AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_sword_4|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): [[LotI_Abilities#cleave_.E2.80.93_damage|cleave]]</span><br/>
 <br/>
-=== Better with Sword &ndash; sword3 ===
+=== Faster with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_4|sword]] and [[#Able_to_Chop_Through_More_Enemies_with_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
@@ -5465,7 +5461,7 @@ This unit also has soul eater AMLA advancements</i></span>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_4|sword]], [[#Able_to_Chop_Through_More_Enemies_with_Sword_.E2.80.93_sword2|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_4|sword]], [[#Able_to_Chop_Through_More_Enemies_with_Sword_.E2.80.93_sword2|sword2]] and [[#Faster_with_Sword_.E2.80.93_sword3_2|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Dealing More Damage with Knives &ndash; knife1 ===
@@ -5515,7 +5511,7 @@ This unit also has soul eater AMLA advancements</i></span>
 <br/>
 === Better at Defending &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_13|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_2|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 2%</span><br/>
@@ -5532,7 +5528,7 @@ This unit also has soul eater AMLA advancements</i></span>
 <br/>
 === Better at Defending &ndash; block3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_.E2.80.93_block_13|block]] and [[#Better_at_Defending_.E2.80.93_block2_5|block2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_.E2.80.93_block_2|block]] and [[#Better_at_Defending_.E2.80.93_block2_2|block2]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 1%</span><br/>
@@ -5547,14 +5543,14 @@ This unit also has soul eater AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 1%</span><br/>
 <br/>
-=== Able to Attack Parrying Enemy Blows &ndash; parry ===
+=== Able to Attack Parrying Enemy Blows (New Attack) &ndash; parry ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: parry (-20% - -70% melee)</span><br/>
 <span style='color:green'>New weapon special for the parry attack: [[LotI_Abilities#parry_.E2.80.93_dummy|parry]]</span><br/>
 <br/>
 === Parrying Better &ndash; parry2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_.E2.80.93_parry_2|parry]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_(New_Attack)_.E2.80.93_parry_2|parry]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the parry attack</span><br/>
 <span style='color:green'>5% more attacks for the parry attack</span><br/>
 <br/>
@@ -5582,7 +5578,7 @@ This unit also has soul eater AMLA advancements</i></span>
 <br/>
 === Faster with Sword (Affects Also Whirlwind) &ndash; sword1_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_7|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <span style='color:green'>1 more attacks for the whirlwind attack</span><br/>
 <br/>
@@ -5603,28 +5599,28 @@ This unit also has soul eater AMLA advancements</i></span>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_7|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Raising Undead with Sword &ndash; sword4_plague ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_7|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the sword attack: plague</span><br/>
 <br/>
 === Better with Sword &ndash; sword5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_7|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Faster with Sword (Affects Also Whirlwind) &ndash; sword5_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_7|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]], [[#Better_with_Sword_.E2.80.93_sword5_5|sword5]] and [[#Faster_with_Sword_(Affects_Also_Whirlwind)_.E2.80.93_sword1_speed_2|sword1_speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]], [[#Better_with_Sword_.E2.80.93_sword5_5|sword5]] and [[#Faster_with_Sword_(Affects_Also_Whirlwind)_.E2.80.93_sword1_speed_2|sword1_speed]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <span style='color:green'>1 more attacks for the whirlwind attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword6 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_7|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_5|sword5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_5|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_8|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_6|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_7|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_5|sword5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Able to Attack Twice in a Row &ndash; berserk1 ===
@@ -6244,14 +6240,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>New weapon special (melee attacks only): [[LotI_Abilities#cleave_.E2.80.93_damage|cleave]]</span><br/>
 <span style='color:green'>Damage increased by 2 (melee attacks only)</span><br/>
 <br/>
-=== Better with Sword &ndash; sword3 ===
+=== Faster with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_5|sword]] and [[#Better_at_Melee_Combat_.E2.80.93_sword2_4|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_5|sword]], [[#Better_at_Melee_Combat_.E2.80.93_sword2_4|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_8|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_5|sword]], [[#Better_at_Melee_Combat_.E2.80.93_sword2_4|sword2]] and [[#Faster_with_Sword_.E2.80.93_sword3_3|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Able to Poison Enemies with Knives &ndash; knife-poison ===
@@ -6282,7 +6278,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Remove ability: [[LotI_Abilities#lesser nightstalk_.E2.80.93_hides|lesser nightstalk]]</span><br/>
 <span style='color:#60A0FF'>New ability: nightstalk</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 3%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 3%</span><br/>
@@ -6298,9 +6294,9 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 3%</span><br/>
 <br/>
-=== Better at Defending &ndash; block2 ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_14|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_4|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 2%</span><br/>
@@ -6315,9 +6311,9 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 2%</span><br/>
 <br/>
-=== Better at Defending &ndash; block3 ===
+=== Better at Defending (Lowering the Chance to be Hit by 1%) &ndash; block3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_.E2.80.93_block_14|block]] and [[#Better_at_Defending_.E2.80.93_block2_6|block2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_4|block]] and [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_2%)_.E2.80.93_block2_2|block2]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 1%</span><br/>
@@ -6332,14 +6328,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on mountains reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on sands reduced by 1%</span><br/>
 <br/>
-=== Able to Attack Parrying Enemy Blows &ndash; parry ===
+=== Able to Attack Parrying Enemy Blows (New Attack) &ndash; parry ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: parry (-20% - -70% melee)</span><br/>
 <span style='color:green'>New weapon special for the parry attack: [[LotI_Abilities#parry_.E2.80.93_dummy|parry]]</span><br/>
 <br/>
 === Parrying Better &ndash; parry2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_.E2.80.93_parry_3|parry]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_(New_Attack)_.E2.80.93_parry_3|parry]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the parry attack</span><br/>
 <span style='color:green'>5% more attacks for the parry attack</span><br/>
 <br/>
@@ -6357,7 +6353,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
-=== Striking Better with Lance &ndash; lance2 ===
+=== Striking Faster with Lance &ndash; lance2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 3 for the lance attack</span><br/>
@@ -6365,45 +6361,45 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Charging More Powerfully with Lance (2.5 Times More Damage) &ndash; lance3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]] and [[#Striking_Better_with_Lance_.E2.80.93_lance2_4|lance2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]] and [[#Striking_Faster_with_Lance_.E2.80.93_lance2_4|lance2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (2.5)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Charging Even More Powerfully with the Lance (3 Times More Damage) &ndash; lance4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]], [[#Striking_Better_with_Lance_.E2.80.93_lance2_4|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_4|lance3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]], [[#Striking_Faster_with_Lance_.E2.80.93_lance2_4|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_4|lance3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the lance attack: [[LotI_Abilities#charge_.E2.80.93_damage|charge (3)]]</span><br/>
 <span style='color:green'>Remove weapon special for the lance attack: charge</span><br/>
 <br/>
 === Striking Even Better with the Lance &ndash; lance5 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]], [[#Striking_Better_with_Lance_.E2.80.93_lance2_4|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_4|lance3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Better_with_Lance_.E2.80.93_lance_4|lance]], [[#Striking_Faster_with_Lance_.E2.80.93_lance2_4|lance2]] and [[#Charging_More_Powerfully_with_Lance_(2.5_Times_More_Damage)_.E2.80.93_lance3_4|lance3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lance attack</span><br/>
 <br/>
-=== Better with Sword &ndash; sword ===
+=== Faster with Sword &ndash; sword ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword_4|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Sword_.E2.80.93_sword|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Better with Sword &ndash; sword3 ===
+=== Faster with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword_4|sword]] and [[#Better_with_Sword_.E2.80.93_sword2_9|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Sword_.E2.80.93_sword|sword]] and [[#Better_with_Sword_.E2.80.93_sword2_9|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword_4|sword]], [[#Better_with_Sword_.E2.80.93_sword2_9|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_9|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_with_Sword_.E2.80.93_sword|sword]], [[#Better_with_Sword_.E2.80.93_sword2_9|sword2]] and [[#Faster_with_Sword_.E2.80.93_sword3_4|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Better with Magic &ndash; lightbeam ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lightbeam attack</span><br/>
 <br/>
-=== Better with Magic &ndash; lightbeam2 ===
+=== Faster with Magic &ndash; lightbeam2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_lightbeam_2|lightbeam]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the lightbeam attack</span><br/>
@@ -6411,7 +6407,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Magic &ndash; lightbeam3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_lightbeam2_2|lightbeam2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Magic_.E2.80.93_lightbeam2_2|lightbeam2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the lightbeam attack</span><br/>
 <br/>
 === Able to Heal Allies Better &ndash; heal ===
@@ -6471,30 +6467,30 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the baneblade attack</span><br/>
 <br/>
-=== Better at Combat with a Scythe &ndash; scythe2 ===
+=== Faster at Combat with a Scythe &ndash; scythe2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe|scythe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the baneblade attack</span><br/>
 <span style='color:green'>1 more attacks for the baneblade attack</span><br/>
 <br/>
-=== Better at Combat with a Scythe &ndash; scythe3 ===
+=== Faster at Combat with a Scythe &ndash; scythe3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe|scythe]] and [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe2|scythe2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe|scythe]] and [[#Faster_at_Combat_with_a_Scythe_.E2.80.93_scythe2|scythe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the baneblade attack</span><br/>
 <span style='color:green'>1 more attacks for the baneblade attack</span><br/>
 <br/>
 === Better at Combat with a Scythe &ndash; scythe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe|scythe]], [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe2|scythe2]] and [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe3|scythe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Combat_with_a_Scythe_.E2.80.93_scythe|scythe]], [[#Faster_at_Combat_with_a_Scythe_.E2.80.93_scythe2|scythe2]] and [[#Faster_at_Combat_with_a_Scythe_.E2.80.93_scythe3|scythe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the baneblade attack</span><br/>
 <br/>
-=== Wailing Louder &ndash; wail ===
+=== Wailing More Times &ndash; wail ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the wail attack</span><br/>
 <br/>
 === Wailing Louder &ndash; wail2 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Wailing_Louder_.E2.80.93_wail|wail]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Wailing_More_Times_.E2.80.93_wail|wail]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the wail attack</span><br/>
 <br/>
 === Wailing so Badly that the Enemies Will be Slowed by it &ndash; wail-slow ===
@@ -6502,20 +6498,20 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Wailing_Louder_.E2.80.93_wail2|wail2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the wail attack: slow</span><br/>
 <br/>
-=== Able to Attack with Claws, that Has a Chance to Slay the Enemy Regardless of His HP &ndash; claws ===
+=== Able to Attack with Claws, that Has a Chance to Slay the Enemy Regardless of His HP (New Attack) &ndash; claws ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New attack: claws (7 - 3, blade)</span><br/>
 <span style='color:green'>New weapon special for the claws attack: [[LotI_Abilities#disintegrate_.E2.80.93_damage|disintegrate]]</span><br/>
 <br/>
 === Clawing Faster &ndash; claws2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Claws,_that_Has_a_Chance_to_Slay_the_Enemy_Regardless_of_His_HP_.E2.80.93_claws|claws]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Claws,_that_Has_a_Chance_to_Slay_the_Enemy_Regardless_of_His_HP_(New_Attack)_.E2.80.93_claws|claws]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the claws attack</span><br/>
 <span style='color:green'>1 more attacks for the claws attack</span><br/>
 <br/>
 === Clawing Better &ndash; claws2-damage ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Claws,_that_Has_a_Chance_to_Slay_the_Enemy_Regardless_of_His_HP_.E2.80.93_claws|claws]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Claws,_that_Has_a_Chance_to_Slay_the_Enemy_Regardless_of_His_HP_(New_Attack)_.E2.80.93_claws|claws]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the claws attack</span><br/>
 <br/>
 === Better at Dodging (Lowering the Chance to be Hit by 5%) &ndash; dodge ===
@@ -6599,14 +6595,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Whirling_Faster_with_Scythe_.E2.80.93_scythe-whirlwind2|scythe-whirlwind2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the whirlwind-scythe attack</span><br/>
 <br/>
-=== Able to Attack with a Confusing Attack &ndash; trickery ===
+=== Able to Attack with a Confusing Attack (New Attack) &ndash; trickery ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: trickery (-20% - -50% melee, copy of scythe)</span><br/>
 <span style='color:green'>New weapon special for the trickery attack: [[LotI_Abilities#trickery_.E2.80.93_dummy|trickery]]</span><br/>
 <br/>
 === Able to Attack Slightly Faster with the Confusing Attack &ndash; trickery2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_a_Confusing_Attack_.E2.80.93_trickery|trickery]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_a_Confusing_Attack_(New_Attack)_.E2.80.93_trickery|trickery]] to be achieved first</i></span><br/>
 <span style='color:green'>10% more attacks for the trickery attack</span><br/>
 <br/>
 === Better Protected from Physical Blows (2% Better Resistances) &ndash; armour ===
@@ -6634,14 +6630,14 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Quarterstaff_.E2.80.93_quarterstaff|quarterstaff]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the staff attack</span><br/>
 <br/>
-=== Striking Better with Quarterstaff &ndash; quarterstaff3 ===
+=== Striking Faster with Quarterstaff &ndash; quarterstaff3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Quarterstaff_.E2.80.93_quarterstaff2|quarterstaff2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the staff attack</span><br/>
 <br/>
-=== Staff &ndash; quarterstaff4 ===
+=== Striking Better with Quarterstaff &ndash; quarterstaff4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Better_with_Quarterstaff_.E2.80.93_quarterstaff3|quarterstaff3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Striking_Faster_with_Quarterstaff_.E2.80.93_quarterstaff3|quarterstaff3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the staff attack</span><br/>
 <br/>
 === Better with Magic &ndash; magic ===
@@ -6664,7 +6660,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_magic3_2|magic3]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#nocturnal ambush_.E2.80.93_hides|nocturnal ambush]]</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 1-2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -6709,17 +6705,17 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
-=== Better with Crossbow &ndash; crossbow ===
+=== Faster with Crossbow &ndash; crossbow ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage decreased by 9 for the crossbow attack</span><br/>
 <span style='color:green'>1 more attacks for the crossbow attack</span><br/>
 <br/>
-=== Better with Magic &ndash; magic ===
+=== Better and Faster with Magic &ndash; magic ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the shadow wave attack</span><br/>
 <span style='color:green'>1 more attacks for the shadow wave attack</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 3%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 3%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 3%</span><br/>
@@ -6740,19 +6736,19 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_sword_6|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Better with Sword &ndash; sword3 ===
+=== Faster at Melee Combat &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_6|sword]] and [[#Better_with_Sword_.E2.80.93_sword2_10|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
-=== Better with Magic &ndash; magic2 ===
+=== Faster with Magic &ndash; magic2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Magic_.E2.80.93_magic_8|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_and_Faster_with_Magic_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the shadow wave attack</span><br/>
 <br/>
 === Better at Defending &ndash; block2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_.E2.80.93_block_16|block]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_5|block]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 2%</span><br/>
@@ -6769,7 +6765,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Defending &ndash; block3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_.E2.80.93_block_16|block]] and [[#Better_at_Defending_.E2.80.93_block2_7|block2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Defending_(Lowering_the_Chance_to_be_Hit_by_3%)_.E2.80.93_block_5|block]] and [[#Better_at_Defending_.E2.80.93_block2_3|block2]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 1%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on flat terrains reduced by 1%</span><br/>
@@ -6786,20 +6782,20 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_6|sword]], [[#Better_with_Sword_.E2.80.93_sword2_10|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_6|sword]], [[#Better_with_Sword_.E2.80.93_sword2_10|sword2]] and [[#Faster_at_Melee_Combat_.E2.80.93_sword3_2|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the saber attack</span><br/>
 <br/>
 === Better with Crossbow &ndash; crossbow2 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Crossbow_.E2.80.93_crossbow_3|crossbow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Crossbow_.E2.80.93_crossbow_2|crossbow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 (pierce attacks only)</span><br/>
 <br/>
 === Better with Magic &ndash; magic3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Magic_.E2.80.93_magic_8|magic]] and [[#Better_with_Magic_.E2.80.93_magic2_3|magic2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Magic_.E2.80.93_magic|magic]] and [[#Faster_with_Magic_.E2.80.93_magic2_2|magic2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (arcane attacks only)</span><br/>
 <br/>
-=== Able to Perform a Whirlwind Attack &ndash; whirlwind ===
+=== Able to Perform a Whirlwind Attack (New Attack) &ndash; whirlwind ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: whirlwind (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the whirlwind attack: [[LotI_Abilities#whirlwind_.E2.80.93_attacks|whirlwind]]</span><br/>
@@ -6807,17 +6803,17 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Whirling Better &ndash; whirlwind2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Perform_a_Whirlwind_Attack_.E2.80.93_whirlwind_3|whirlwind]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Perform_a_Whirlwind_Attack_(New_Attack)_.E2.80.93_whirlwind_3|whirlwind]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the whirlwind attack</span><br/>
 <br/>
-=== Able to Attack Parrying Enemy Blows &ndash; parry ===
+=== Able to Attack Parrying Enemy Blows (New Attack) &ndash; parry ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: parry (-20% - -70% melee)</span><br/>
 <span style='color:green'>New weapon special for the parry attack: [[LotI_Abilities#parry_.E2.80.93_dummy|parry]]</span><br/>
 <br/>
 === Parrying Better &ndash; parry2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_.E2.80.93_parry_4|parry]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_(New_Attack)_.E2.80.93_parry_4|parry]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the parry attack</span><br/>
 <span style='color:green'>5% more attacks for the parry attack</span><br/>
 <br/>
@@ -6827,7 +6823,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 
 == Siege Troll ==
-<span style='color:#808080'><i>Trolls rarely use more than the most basic of equipment.  The Orcish tribes will occasionally outfit the biggest, strongest, toughest Troll they can find with heavy armor and use it as a siege weapon.<br/>
+<span style='color:#808080'><i>Trolls rarely use more than the most basic of equipment. The Orcish tribes will occasionally outfit the biggest, strongest, toughest Troll they can find with heavy armor and use it as a siege weapon.<br/>
 Special Notes: This unit regenerates, which allows it to heal as though always stationed in a village.<br/>
 This unit also has generic AMLA advancements</i></span>
 
@@ -6851,23 +6847,23 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Stronger_with_Hammer_.E2.80.93_hammer2_2|hammer2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the hammer attack</span><br/>
 <br/>
-=== Able to Attack in a Terribly Scary Way &ndash; horrid ===
+=== Able to Attack in a Terribly Scary Way (New Attack) &ndash; horrid ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: grim strike (-20% - 100% melee)</span><br/>
 <span style='color:green'>New weapon special for the grim strike attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <br/>
 === Scaring Enemies with the Scary Attack Better &ndash; horrid2 ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terribly_Scary_Way_.E2.80.93_horrid_3|horrid]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terribly_Scary_Way_(New_Attack)_.E2.80.93_horrid_3|horrid]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the grim strike attack</span><br/>
 <br/>
-=== Able to Attack and Defend with a Single, Devastating Blow &ndash; devastation ===
+=== Able to Attack and Defend with a Single, Devastating Blow (New Attack) &ndash; devastation ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: devastation (-40% - 100% melee)</span><br/>
 <br/>
 === Attacking Better with the Single Blow &ndash; devastation2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_and_Defend_with_a_Single,_Devastating_Blow_.E2.80.93_devastation|devastation]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_and_Defend_with_a_Single,_Devastating_Blow_(New_Attack)_.E2.80.93_devastation|devastation]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the devastation attack</span><br/>
 <br/>
 === Better Protected from Physical Blows (2% Better Resistances) &ndash; armour ===
@@ -6948,7 +6944,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>Damage decreased by 5 for the claws attack</span><br/>
 <span style='color:green'>1 more attacks for the claws attack</span><br/>
 <br/>
-=== Able to Breathe Dark Energy &ndash; breath ===
+=== Able to Breathe Dark Energy (New Attack) &ndash; breath ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New attack: dark breath (12 - 2, arcane)</span><br/>
 <span style='color:green'>New weapon special for the dark breath attack: slow</span><br/>
@@ -6956,13 +6952,13 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Breathing Dark Energy Faster &ndash; breath_speed ===
 <span style='color:#808080'><i>This advancement can be taken 2 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Breathe_Dark_Energy_.E2.80.93_breath|breath]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Breathe_Dark_Energy_(New_Attack)_.E2.80.93_breath|breath]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2 for the dark breath attack</span><br/>
 <span style='color:green'>1 more attacks for the dark breath attack</span><br/>
 <br/>
 === Breathing Darker Energy Better &ndash; breath_damage ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Breathe_Dark_Energy_.E2.80.93_breath|breath]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Breathe_Dark_Energy_(New_Attack)_.E2.80.93_breath|breath]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the dark breath attack</span><br/>
 <br/>
 === Faster &ndash; movement ===
@@ -6989,25 +6985,25 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>Damage decreased by 1 (ranged attacks only)</span><br/>
 <span style='color:green'>1 more attacks (ranged attacks only)</span><br/>
 <br/>
-=== Better with Bow &ndash; bow2 ===
+=== Better with the Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow_3|bow]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
-=== Shooting Insanely Precisely &ndash; bow-precise ===
+=== More Precise with the Bow &ndash; bow-precise ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_3|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_6|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]] and [[#Better_with_the_Bow_.E2.80.93_bow2_2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (ranged attacks only): marksman</span><br/>
 <span style='color:green'>Damage decreased by 1 (ranged attacks only)</span><br/>
 <br/>
-=== Better with the Bow &ndash; bow3 ===
+=== Faster with the Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_3|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_6|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]] and [[#Better_with_the_Bow_.E2.80.93_bow2_2|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (ranged attacks only)</span><br/>
 <br/>
 === Better with the Bow &ndash; bow4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_3|bow]], [[#Better_with_Bow_.E2.80.93_bow2_6|bow2]] and [[#Better_with_the_Bow_.E2.80.93_bow3_2|bow3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_the_Bow_.E2.80.93_bow_2|bow]], [[#Better_with_the_Bow_.E2.80.93_bow2_2|bow2]] and [[#Faster_with_the_Bow_.E2.80.93_bow3_5|bow3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
 === A Skirmisher &ndash; skirmisher ===
@@ -7042,14 +7038,14 @@ Because of the constant danger and harsh weather condition the Snow Elves live i
 Special Notes: This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== A Better Fighter &ndash; melee ===
+=== A Much Better Fighter &ndash; melee ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === A Better Fighter &ndash; melee2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Fighter_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#A_Much_Better_Fighter_.E2.80.93_melee|melee]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 (melee attacks only)</span><br/>
 <br/>
 === A Better Fighter &ndash; melee3 ===
@@ -7062,16 +7058,16 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#A_Better_Fighter_.E2.80.93_melee3|melee3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Better with Bolas &ndash; bolas ===
+=== Faster with Bolas &ndash; bolas ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks for the bolas attack</span><br/>
 <br/>
 === Better with Bolas &ndash; bolas2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Bolas_.E2.80.93_bolas|bolas]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Bolas_.E2.80.93_bolas|bolas]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the bolas attack</span><br/>
 <br/>
-=== Better with Bolas &ndash; bolas3 ===
+=== Faster with Bolas &ndash; bolas3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Bolas_.E2.80.93_bolas2|bolas2]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the bolas attack</span><br/>
@@ -7092,30 +7088,30 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 5%</span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 5%</span><br/>
 <br/>
-=== More Used to Frozen Lands &ndash; coldlife3 ===
+=== More Used to Frozen Lands (+20% Cold Resistance) &ndash; coldlife3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Frost-Hardier_(Defence_+_Cold_Resistance_on_Frozen_Terrains_+5%)_.E2.80.93_coldlife2|coldlife2]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>Resistance to cold increased by 20%</span><br/>
 <br/>
 === More Used to Frozen Lands (Hiding on Snow) &ndash; coldlife4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#More_Used_to_Frozen_Lands_.E2.80.93_coldlife3|coldlife3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#More_Used_to_Frozen_Lands_(+20%_Cold_Resistance)_.E2.80.93_coldlife3|coldlife3]] to be achieved first</i></span><br/>
 <span style='color:#60A0FF'>New ability: [[LotI_Abilities#snow ambush_.E2.80.93_hides|snow ambush]]</span><br/>
 <br/>
-=== Proficient with Cold Magic &ndash; magic ===
+=== Proficient with Cold Magic (New Attack) &ndash; magic ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New attack: ice bolt (11 - 2, cold)</span><br/>
 <span style='color:green'>New weapon special for the ice bolt attack: magical</span><br/>
 <br/>
-=== More Proficient with Cold Magic &ndash; magic2 ===
+=== Faster with Cold Magic &ndash; magic2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Proficient_with_Cold_Magic_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Proficient_with_Cold_Magic_(New_Attack)_.E2.80.93_magic|magic]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the ice bolt attack</span><br/>
 <span style='color:green'>1 more attacks for the ice bolt attack</span><br/>
 <br/>
 === More Proficient with Cold Magic &ndash; magic3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#More_Proficient_with_Cold_Magic_.E2.80.93_magic2|magic2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Cold_Magic_.E2.80.93_magic2|magic2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 3 for the ice bolt attack</span><br/>
 <br/>
 === More Proficient with Cold Magic &ndash; magic4 ===
@@ -7123,7 +7119,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#More_Proficient_with_Cold_Magic_.E2.80.93_magic3|magic3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the ice bolt attack</span><br/>
 <br/>
-=== More Proficient with Cold Magic &ndash; magic5 ===
+=== Faster with Cold Magic &ndash; magic5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#More_Proficient_with_Cold_Magic_.E2.80.93_magic4|magic4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 2 for the ice bolt attack</span><br/>
@@ -7131,10 +7127,10 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === More Proficient with Cold Magic &ndash; magic6 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#More_Proficient_with_Cold_Magic_.E2.80.93_magic5|magic5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Cold_Magic_.E2.80.93_magic5|magic5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the ice bolt attack</span><br/>
 <br/>
-=== Able to Summon a Blizzard &ndash; blizzard ===
+=== Able to Summon a Blizzard (New Attack) &ndash; blizzard ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements [[#More_Proficient_with_Cold_Magic_.E2.80.93_magic6|magic6]] and [[#More_Used_to_Frozen_Lands_(Hiding_on_Snow)_.E2.80.93_coldlife4|coldlife4]] to be achieved first</i></span><br/>
 <span style='color:green'>New attack: blizzard (14 - 2, cold)</span><br/>
@@ -7143,7 +7139,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Summoning Better Blizzards &ndash; blizzard2 ===
 <span style='color:#808080'><i>This advancement can be taken 4 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Summon_a_Blizzard_.E2.80.93_blizzard|blizzard]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Summon_a_Blizzard_(New_Attack)_.E2.80.93_blizzard|blizzard]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 2 for the blizzard attack</span><br/>
 <br/>
 === Faster &ndash; movement ===
@@ -7160,7 +7156,7 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
-=== Better with Bow &ndash; bow2 ===
+=== Faster with Bow &ndash; bow2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Bow_.E2.80.93_bow_2|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 (ranged attacks only)</span><br/>
@@ -7168,7 +7164,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Bow &ndash; bow3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Bow_.E2.80.93_bow_2|bow]] and [[#Better_with_Bow_.E2.80.93_bow2_7|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Bow_.E2.80.93_bow_2|bow]] and [[#Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (ranged attacks only)</span><br/>
 <br/>
 === More Precise with Bow &ndash; bow-marksman ===
@@ -7176,9 +7172,9 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Bow_.E2.80.93_bow_2|bow]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (ranged attacks only): marksman</span><br/>
 <br/>
-=== Leeching Enemies with Bow &ndash; bow-leech ===
+=== Leeching Health from Enemies with Bow &ndash; bow-leech ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Bow_.E2.80.93_bow2_7|bow2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Bow_.E2.80.93_bow2_3|bow2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (ranged attacks only): [[LotI_Abilities#leeches_.E2.80.93_damage|leech]]</span><br/>
 <br/>
 === Turning Enemies into Undead with Poison from Bow &ndash; bow-infect ===
@@ -7187,32 +7183,32 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>New weapon special (ranged attacks only): [[LotI_Abilities#infect_.E2.80.93_poison|infect]]</span><br/>
 <span style='color:green'>Remove weapon special (ranged attacks only): poison</span><br/>
 <br/>
-=== Able to Shoot Cursed Arcane Arrows &ndash; arcane ===
+=== Able to Shoot Cursed Arcane Arrows (New Attack) &ndash; arcane ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: cursed arrow (-20% - 100% ranged arcane)</span><br/>
 <br/>
 === Shooting Cursed Arrows Better &ndash; arcane2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Shoot_Cursed_Arcane_Arrows_.E2.80.93_arcane|arcane]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Shoot_Cursed_Arcane_Arrows_(New_Attack)_.E2.80.93_arcane|arcane]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the cursed arrow attack</span><br/>
 <br/>
 === Better with Dagger &ndash; dagger ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
-=== Better with Dagger &ndash; dagger2 ===
+=== Faster with Dagger &ndash; dagger2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Dagger_.E2.80.93_dagger_2|dagger]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Better with Dagger &ndash; dagger3 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Dagger_.E2.80.93_dagger_2|dagger]] and [[#Better_with_Dagger_.E2.80.93_dagger2_2|dagger2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Dagger_.E2.80.93_dagger_2|dagger]] and [[#Faster_with_Dagger_.E2.80.93_dagger2|dagger2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === Able to Backstab with Dagger &ndash; dagger-backstab ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Dagger_.E2.80.93_dagger_2|dagger]], [[#Better_with_Dagger_.E2.80.93_dagger2_2|dagger2]] and [[#Better_with_Dagger_.E2.80.93_dagger3|dagger3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Dagger_.E2.80.93_dagger_2|dagger]], [[#Faster_with_Dagger_.E2.80.93_dagger2|dagger2]] and [[#Better_with_Dagger_.E2.80.93_dagger3|dagger3]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special (melee attacks only): backstab</span><br/>
 <br/>
 === More Undead-Like Resistance (Improved Resistances, Slightly Worsened Weaknesses) &ndash; armour ===
@@ -7246,32 +7242,32 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Striking Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_6|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_8|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Striking_Faster_with_Sword_.E2.80.93_sword2_8|sword2]] and [[#Striking_Better_with_Sword_.E2.80.93_sword_8|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Able to Attack Parrying Enemy Blows &ndash; parry ===
+=== Able to Attack Parrying Enemy Blows (New Attack) &ndash; parry ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: parry (-20% - -70% melee)</span><br/>
 <span style='color:green'>New weapon special for the parry attack: [[LotI_Abilities#parry_.E2.80.93_dummy|parry]]</span><br/>
 <br/>
 === Parrying Better &ndash; parry2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_.E2.80.93_parry_5|parry]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_Parrying_Enemy_Blows_(New_Attack)_.E2.80.93_parry_5|parry]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the parry attack</span><br/>
 <span style='color:green'>5% more attacks for the parry attack</span><br/>
 <br/>
-=== Able to Attack in a Terrible Way that Lowers Enemy Resistance &ndash; doom ===
+=== Able to Attack in a Terrible Way that Lowers Enemy Resistance (New Attack) &ndash; doom ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: doom (-30% - -30% melee)</span><br/>
 <span style='color:green'>New weapon special for the doom attack: [[LotI_Abilities#doom_.E2.80.93_dummy|doom]]</span><br/>
 <br/>
 === Crippling Enemies Better &ndash; doom2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_.E2.80.93_doom_4|doom]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_in_a_Terrible_Way_that_Lowers_Enemy_Resistance_(New_Attack)_.E2.80.93_doom_4|doom]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the doom attack</span><br/>
 <span style='color:green'>5% more attacks for the doom attack</span><br/>
 <br/>
-=== Better at Defending &ndash; block ===
+=== Better at Defending (Lowering the Chance to be Hit by 2%) &ndash; block ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
 <span style='color:#60A0FF'>Chance to get hit in forests reduced by 2%</span><br/>
 <span style='color:#60A0FF'>Chance to get hit on frozen places reduced by 2%</span><br/>
@@ -7393,15 +7389,15 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
-=== Better with Sword &ndash; sword2 ===
+=== Faster with Sword &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword_5|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword_4|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the sword attack</span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Sword_.E2.80.93_sword2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Causing More Havoc with Magic &ndash; magic1 ===
@@ -7441,22 +7437,22 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:green'>Enemy resistances to cold decreased by 7%</span><br/>
 <span style='color:green'>Enemy resistances to arcane decreased by 7%</span><br/>
 <br/>
-=== Able to Attack with Magically Increased Speed &ndash; speed ===
+=== Able to Attack with Magically Increased Speed (New Attack) &ndash; speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: speed (-30% - 100% melee)</span><br/>
 <br/>
 === Attacking Better Under the Effect of Quickening Spell &ndash; speed2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Increased_Speed_.E2.80.93_speed|speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Increased_Speed_(New_Attack)_.E2.80.93_speed|speed]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the speed attack</span><br/>
 <br/>
-=== Able to Attack with Magically Flaming Sword &ndash; fire ===
+=== Able to Attack with Magically Flaming Sword (New Attack) &ndash; fire ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: fiery saber (100%, 100% melee fire)</span><br/>
 <br/>
 === Attacking Better with the Flaming Sword &ndash; fire2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Flaming_Sword_.E2.80.93_fire|fire]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Flaming_Sword_(New_Attack)_.E2.80.93_fire|fire]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the fiery saber attack</span><br/>
 <br/>
 === Better at Dodging (Lowering the Chance to be Hit by 2%) &ndash; dodge ===
@@ -7492,7 +7488,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Faster with Sword &ndash; sword1_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_12|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_8|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword2 ===
@@ -7502,32 +7498,32 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_12|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_8|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Slowing Enemies with Sword &ndash; sword4_plague ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the sword attack: slow</span><br/>
 <br/>
 === Better with Sword &ndash; sword5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_12|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_11|sword4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_8|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_11|sword4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Faster with Sword &ndash; sword5_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_12|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_11|sword4]], [[#Better_with_Sword_.E2.80.93_sword5_6|sword5]] and [[#Faster_with_Sword_.E2.80.93_sword1_speed_4|sword1_speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_8|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_11|sword4]], [[#Better_with_Sword_.E2.80.93_sword5_6|sword5]] and [[#Faster_with_Sword_.E2.80.93_sword1_speed_4|sword1_speed]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword6 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_12|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_11|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_6|sword5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_6|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_11|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_8|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_11|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_6|sword5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Able to Attack Thrice in a Row &ndash; berserk2 ===
@@ -7545,23 +7541,23 @@ This unit also has generic AMLA advancements</i></span>
 === Doing More Damage with the Furious Attack &ndash; berserk1_damage ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement berserk1 to be achieved first</i></span><br/>
-<span style='color:green'>Damage increased by 10% for the mberserk attack</span><br/>
 <span style='color:green'>Damage increased by 10% for the mberserk2 attack</span><br/>
 <span style='color:green'>Damage increased by 10% for the mberserk3 attack</span><br/>
+<span style='color:green'>Damage increased by 10% for the mberserk5 attack</span><br/>
 <br/>
 === Attacking Horrendously with Berserk Attacks &ndash; berserk2_damage ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements berserk1 and [[#Doing_More_Damage_with_the_Furious_Attack_.E2.80.93_berserk1_damage_3|berserk1_damage]] to be achieved first</i></span><br/>
-<span style='color:green'>New weapon special for the mberserk attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <span style='color:green'>New weapon special for the mberserk2 attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <span style='color:green'>New weapon special for the mberserk3 attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
+<span style='color:green'>New weapon special for the mberserk5 attack: [[LotI_Abilities#horrid_.E2.80.93_dummy|horrid]]</span><br/>
 <br/>
 === Doing More Damage with the Furious Attack &ndash; berserk3_damage ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancements berserk1 and [[#Doing_More_Damage_with_the_Furious_Attack_.E2.80.93_berserk1_damage_3|berserk1_damage]] to be achieved first</i></span><br/>
-<span style='color:green'>Damage increased by 10% for the mberserk attack</span><br/>
 <span style='color:green'>Damage increased by 10% for the mberserk2 attack</span><br/>
 <span style='color:green'>Damage increased by 10% for the mberserk3 attack</span><br/>
+<span style='color:green'>Damage increased by 10% for the mberserk5 attack</span><br/>
 <br/>
 === Causing More Havoc with Magic &ndash; faerie1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
@@ -7696,7 +7692,7 @@ This unit also has generic AMLA advancements</i></span>
 
 == Unholy Breed (Vritra) ==
 <span style='color:#808080'><i>Born from a special breed between a serpent and an elf, she inherited elvish appearance and intelligence, and serpent-like malice and dexterity. She is rather good than evil because of her education, but the evil power within her is still hard to control. If it gets bad, a healing potion might help her.<br/>
-Special Notes: This unit regenerates, which allows it to heal as though always stationed in a village. This unit has magical attacks, which always have a high chance of hitting an opponent. During battle, this unit can drain life from victims to renew its own health. This unit’s skill at skirmishing allows it to ignore enemies’ zones of control and thus move unhindered around them.<br/>
+Special Notes: This unit regenerates, which allows it to heal as though always stationed in a village. This unit has magical attacks, which always have a high chance of hitting an opponent. During battle, this unit can drain life from victims to renew its own health. This unit’s skill at skirmishing allows it to ignore enemies’ zones of control and thus move unhindered around them. This unit is able to slow its enemies, halving their movement speed and attack damage until they end a turn. The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures. This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures.<br/>
 This unit also has generic AMLA advancements</i></span>
 
 === Oops, Something Went Wrong &ndash; backup_amla ===
@@ -7707,18 +7703,18 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This unit is shrouded in mystery. No one knows who she is, and why she is like she is.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Better at Melee Combat &ndash; sword ===
+=== Faster at Melee Combat &ndash; sword ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
-=== Better at Melee Combat &ndash; sword2 ===
+=== Faster at Melee Combat &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Melee_Combat_.E2.80.93_sword_3|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Melee_Combat_.E2.80.93_sword_7|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks (melee attacks only)</span><br/>
 <br/>
 === Better at Melee Combat &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Melee_Combat_.E2.80.93_sword_3|sword]] and [[#Better_at_Melee_Combat_.E2.80.93_sword2_5|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Faster_at_Melee_Combat_.E2.80.93_sword_7|sword]] and [[#Faster_at_Melee_Combat_.E2.80.93_sword2_2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 (melee attacks only)</span><br/>
 <br/>
 === A Faster Caster &ndash; magic ===
@@ -7755,7 +7751,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Faster with Sword (Affects Also Whirlwind) &ndash; sword1_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_13|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_9|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <span style='color:green'>1 more attacks for the whirlwind attack</span><br/>
 <br/>
@@ -7771,14 +7767,14 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_7|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_7|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_12|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Whirling Better &ndash; whirlwind ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the whirlwind attack</span><br/>
 <br/>
-=== Better with Knives &ndash; knives1 ===
+=== Better and Faster with Knives &ndash; knives1 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the knife attack</span><br/>
 <span style='color:green'>1 more attacks for the knife attack</span><br/>
@@ -7789,12 +7785,12 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Knives &ndash; knives2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Knives_.E2.80.93_knives1_3|knives1]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_and_Faster_with_Knives_.E2.80.93_knives1|knives1]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the knife attack</span><br/>
 <br/>
 === More Precise with Knives &ndash; knives2_precision ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Knives_.E2.80.93_knives1_3|knives1]] and [[#Better_with_Knives_.E2.80.93_knives2_3|knives2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_and_Faster_with_Knives_.E2.80.93_knives1|knives1]] and [[#Better_with_Knives_.E2.80.93_knives2_3|knives2]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the knife attack: marksman</span><br/>
 <br/>
 === Causing a Spine-Chilling Fear &ndash; fear1_spine_chill ===
@@ -7967,7 +7963,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Faster with Sword &ndash; sword1_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_14|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword2 ===
@@ -7982,32 +7978,32 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_14|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]] and [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword4 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_14|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_14|sword3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]] and [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Slowing Enemies with Sword &ndash; sword4_plague ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_14|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_14|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]] to be achieved first</i></span><br/>
 <span style='color:green'>New weapon special for the sword attack: slow</span><br/>
 <br/>
 === Better with Sword &ndash; sword5 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_14|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_14|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]] and [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Faster with Sword &ndash; sword5_speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_14|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_14|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]], [[#Better_with_Sword_.E2.80.93_sword5_7|sword5]] and [[#Faster_with_Sword_.E2.80.93_sword1_speed_5|sword1_speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]], [[#Better_with_Sword_.E2.80.93_sword5_7|sword5]] and [[#Faster_with_Sword_.E2.80.93_sword1_speed_5|sword1_speed]] to be achieved first</i></span><br/>
 <span style='color:green'>1 more attacks for the sword attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword6 ===
 <span style='color:#808080'><i>This advancement can be taken 5 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_14|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_14|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_7|sword5]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_with_Sword_.E2.80.93_sword1_8|sword1]], [[#Better_with_Sword_.E2.80.93_sword2_13|sword2]], [[#Better_with_Sword_.E2.80.93_sword3_10|sword3]], [[#Better_with_Sword_.E2.80.93_sword4_12|sword4]] and [[#Better_with_Sword_.E2.80.93_sword5_7|sword5]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the sword attack</span><br/>
 <br/>
 === Able to Attack Twice in a Row &ndash; berserk1 ===
@@ -8180,22 +8176,22 @@ This unit also has generic AMLA advancements</i></span>
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the saber attack</span><br/>
 <br/>
-=== Better with Sword &ndash; sword2 ===
+=== Faster with Sword &ndash; sword2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword_6|sword]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword_5|sword]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the saber attack</span><br/>
 <span style='color:green'>1 more attacks for the saber attack</span><br/>
 <br/>
 === Better with Sword &ndash; sword3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Sword_.E2.80.93_sword2_15|sword2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Sword_.E2.80.93_sword2_2|sword2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the saber attack</span><br/>
 <br/>
 === Better with Fireball &ndash; fireball ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
-=== Better with Fireball &ndash; fireball2 ===
+=== Faster with Fireball &ndash; fireball2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball_6|fireball]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the fireball attack</span><br/>
@@ -8203,25 +8199,25 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better with Fireball &ndash; fireball3 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_with_Fireball_.E2.80.93_fireball2_3|fireball2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_with_Fireball_.E2.80.93_fireball2_5|fireball2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the fireball attack</span><br/>
 <br/>
-=== Able to Attack with Magically Increased Speed &ndash; speed ===
+=== Able to Attack with Magically Increased Speed (New Attack) &ndash; speed ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: speed (-30% - 100% melee)</span><br/>
 <br/>
 === Attacking Better Under the Effect of Quickening Spell &ndash; speed2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Increased_Speed_.E2.80.93_speed_2|speed]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Increased_Speed_(New_Attack)_.E2.80.93_speed_2|speed]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the speed attack</span><br/>
 <br/>
-=== Able to Attack with Magically Flaming Sword &ndash; fire ===
+=== Able to Attack with Magically Flaming Sword (New Attack) &ndash; fire ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>New bonus attack: fiery saber (100%, 100% melee fire)</span><br/>
 <br/>
 === Attacking Better with the Flaming Sword &ndash; fire2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Flaming_Sword_.E2.80.93_fire_2|fire]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Able_to_Attack_with_Magically_Flaming_Sword_(New_Attack)_.E2.80.93_fire_2|fire]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 15% for the fiery saber attack</span><br/>
 <br/>
 === Much More Resilient (Much More Antisocial, Though) &ndash; social_skill ===
@@ -8266,17 +8262,17 @@ This unit also has generic AMLA advancements</i></span>
 Special Notes: The victims of this unit’s poison will continually take damage until they can be cured in town or by a unit which cures.<br/>
 This unit also has generic AMLA advancements</i></span>
 
-=== Better at Clawing &ndash; claws ===
+=== Faster at Clawing &ndash; claws ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the claws attack</span><br/>
 <span style='color:green'>1 more attacks for the claws attack</span><br/>
 <br/>
 === Better at Clawing &ndash; claws2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Clawing_.E2.80.93_claws|claws]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Clawing_.E2.80.93_claws|claws]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the claws attack</span><br/>
 <br/>
-=== Better at Clawing &ndash; claws3 ===
+=== Faster at Clawing &ndash; claws3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Clawing_.E2.80.93_claws2|claws2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the claws attack</span><br/>
@@ -8284,10 +8280,10 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Clawing &ndash; claws4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Clawing_.E2.80.93_claws3|claws3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Faster_at_Clawing_.E2.80.93_claws3|claws3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the claws attack</span><br/>
 <br/>
-=== Able to Claw in a Violent Fury &ndash; berserk ===
+=== Able to Claw in a Violent Fury (New Attack) &ndash; berserk ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
 <span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Clawing_.E2.80.93_claws2|claws2]] to be achieved first</i></span><br/>
 <span style='color:green'>New bonus attack: fury (100%, 100% melee, copy of claws)</span><br/>
@@ -8295,7 +8291,7 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Clawing in an Even More Vicious Berserk &ndash; berserk2 ===
 <span style='color:#808080'><i>This advancement can be taken 3 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Clawing_.E2.80.93_claws2|claws2]] and [[#Able_to_Claw_in_a_Violent_Fury_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Clawing_.E2.80.93_claws2|claws2]] and [[#Able_to_Claw_in_a_Violent_Fury_(New_Attack)_.E2.80.93_berserk|berserk]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 10% for the fury attack</span><br/>
 <span style='color:green'>10% more attacks for the fury attack</span><br/>
 <br/>
@@ -8354,18 +8350,18 @@ This unit also has generic AMLA advancements</i></span>
 <br/>
 === Better at Axe Combat &ndash; axe2 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe_4|axe]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancement [[#Better_at_Axe_Combat_.E2.80.93_axe_3|axe]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the axe attack</span><br/>
 <br/>
-=== Better at Axe Combat &ndash; axe3 ===
+=== Faster at Axe Combat &ndash; axe3 ===
 <span style='color:#808080'><i>This advancement can be taken once</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_4|axe]] and [[#Better_at_Axe_Combat_.E2.80.93_axe2_3|axe2]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_3|axe]] and [[#Better_at_Axe_Combat_.E2.80.93_axe2_3|axe2]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage decreased by 1 for the axe attack</span><br/>
 <span style='color:green'>1 more attacks for the axe attack</span><br/>
 <br/>
 === Better at Axe Combat &ndash; axe4 ===
 <span style='color:#808080'><i>This advancement can be taken 10 times</i></span><br/>
-<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_4|axe]], [[#Better_at_Axe_Combat_.E2.80.93_axe2_3|axe2]] and [[#Better_at_Axe_Combat_.E2.80.93_axe3_3|axe3]] to be achieved first</i></span><br/>
+<span style='color:#808080'><i>This advancement requires the advancements [[#Better_at_Axe_Combat_.E2.80.93_axe_3|axe]], [[#Better_at_Axe_Combat_.E2.80.93_axe2_3|axe2]] and [[#Faster_at_Axe_Combat_.E2.80.93_axe3_3|axe3]] to be achieved first</i></span><br/>
 <span style='color:green'>Damage increased by 1 for the axe attack</span><br/>
 <br/>
 === Transforming Enemies into Soulless with the Plague &ndash; soulless ===


### PR DESCRIPTION
hey! I updated the wiki stuff so it works with the latest stable (3.2.6d) version of LotI. (I have not tried running it on the loti git repository though).
The main change is that some campaign specific special notes which are used for the "Unit advancements" page were added as macros to the abilities.cfg file. I had extract_abilities read those and update the special_notes_translation dict for the unit extractor to use. There's also an item (Violent mage's staff) with a passive requirement that doesn't map to another item (New ability: firecast (requires the two other Violent Mage's items)) so I just changed the item querying to leave the text alone in that case.
I also sorted the Items and Abilities wiki pages by type because I think it's a lot more readable that way.
I'm happy to make changes if you have any corrections/suggestions.
-Inky